### PR TITLE
Do something useful with GET response bodies

### DIFF
--- a/lib/discourse_api/resource.rb
+++ b/lib/discourse_api/resource.rb
@@ -43,7 +43,7 @@ class DiscourseApi::Resource
     actual_args = api_args(actual_args)
     req = Net::HTTP::Get.new(path, initheader = {'Content-Type' =>'application/json'})
     r = http_client.start {|http| http.request(req) }
-    puts r.body
+    parse_result( r.body )
   end
 
   def perform_post(parsed_path, args)
@@ -57,6 +57,9 @@ class DiscourseApi::Resource
   end
 
   private
+    def parse_result( text )
+      JSON.parse( text, :create_extensions => false )
+    end
 
     def http_client
       if protocol == 'https'


### PR DESCRIPTION
I've just starting using this gem for a bridge component that sites at arms-length from discourse. My application needs to be able to access the response data somehow - this just safely parses the json and returns it as a ruby hash or array. 
