### PR TITLE
Clean up repetition in DiscourseApi::Resource

### DIFF
--- a/lib/discourse_api/resource.rb
+++ b/lib/discourse_api/resource.rb
@@ -4,97 +4,64 @@ require 'json'
 class DiscourseApi::Resource
   attr_accessor :protocol, :host, :port, :api_key, :api_username
 
-  def self.put(args)
-    # ruby 1.9.3 for now
-    array_args = args.to_a
-    method_name, path = array_args[0]
-    route_args = {}
-    array_args[1..-1].each do |k, v|
-      route_args[k] = v
-    end
-
-    define_method method_name do |args|
-      parsed_path = DiscourseApi::ParsedPath.new(path, route_args)
-      perform_put(parsed_path, args)
-    end
+  def self.get(args)
+    self.build_request(:get, args)
   end
 
   def self.post(args)
-    # ruby 1.9.3 for now
-    array_args = args.to_a
-    method_name, path = array_args[0]
-    route_args = {}
-    array_args[1..-1].each do |k, v|
-      route_args[k] = v
-    end
-
-    define_method method_name do |args|
-      parsed_path = DiscourseApi::ParsedPath.new(path, route_args)
-      perform_post(parsed_path, args)
-    end
+    self.build_request(:post, args)
   end
 
-  def self.get(args)
-    # ruby 1.9.3 for now
-    array_args = args.to_a
-    method_name, path = array_args[0]
-    route_args = {}
-    array_args[1..-1].each do |k, v|
-      route_args[k] = v
-    end
-    define_method method_name do |args|
-      parsed_path = DiscourseApi::ParsedPath.new(path, route_args)
-      perform_get(parsed_path, args)
-    end
+  def self.put(args)
+    self.build_request(:put, args)
   end
 
   def api_args(args)
     args.merge(:api_key => self.api_key, :api_username => self.api_username)
   end
 
-  def perform_get(parsed_path, args)
-    parsed_path.validate!(args)
-    path, actual_args = parsed_path.generate(args)
-    actual_args = api_args(actual_args)
-    req = Net::HTTP::Get.new(path, initheader = {'Content-Type' =>'application/json'})
-    r = http_client.start {|http| http.request(req) }
-    parse_result( r.body )
-  end
-
-  def perform_post(parsed_path, args)
-    parsed_path.validate!(args)
-    path, actual_args = parsed_path.generate(args)
-    actual_args = api_args(actual_args)
-
-    req = Net::HTTP::Post.new(path, initheader = {'Content-Type' =>'application/json'})
-    req.body = api_args(actual_args).to_json
-    http_client.start {|http| http.request(req) }
-  end
-
-  def perform_put(parsed_path, args)
-    parsed_path.validate!(args)
-    path, actual_args = parsed_path.generate(args)
-    actual_args = api_args(actual_args)
-
-    req = Net::HTTP::Put.new(path, initheader = {'Content-Type' =>'application/json'})
-    req.body = api_args(actual_args).to_json
-    http_client.start {|http| http.request(req) }
-  end
-
   private
-    def parse_result( text )
-      JSON.parse( text, :create_extensions => false )
+
+  def http_client
+    if protocol == 'https'
+      client = Net::HTTP.new(host, port)
+      client.use_ssl = true
+      client.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      client
+    else
+      Net::HTTP.new(host, port)
+    end
+  end
+
+  def parse_result( text )
+    JSON.parse( text, :create_extensions => false )
+  end
+
+  def perform(method, parsed_path, args)
+    parsed_path.validate!(args)
+    path, actual_args = parsed_path.generate(args)
+    actual_args = api_args(actual_args)
+
+    request_type = Object.const_get("Net::HTTP::#{method.to_s.capitalize}")
+    req = request_type.new(path, initheader = {'Content-Type' =>'application/json'})
+    req.body = api_args(actual_args).to_json if [:post, :put].include? method
+
+    http_client.start {|http| http.request(req) }
+  end
+
+  def self.build_request(method, args)
+    # ruby 1.9.3 for now
+    array_args = args.to_a
+    method_name, path = array_args[0]
+    route_args = {}
+    array_args[1..-1].each do |k, v|
+      route_args[k] = v
     end
 
-    def http_client
-      if protocol == 'https'
-        client = Net::HTTP.new(host, port)
-        client.use_ssl = true
-        client.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        client
-      else
-        Net::HTTP.new(host, port)
-      end
+    define_method method_name do |args|
+      parsed_path = DiscourseApi::ParsedPath.new(path, route_args)
+      perform(method, parsed_path, args)
     end
+  end
 
 end


### PR DESCRIPTION
I noticed a lot of repetition was bringing down the Code Climate GPA, so thought I'd clean it up. All tests still pass, nothing new was added in this change set.

I wanted to do something small for my first contribution. Since the [contribution guidelines](http://meta.discourse.org/t/so-you-want-to-help-out-with-discourse/3823) say you're going for a 4.0 on Code Climate, I thought this would be a good first step.

**Edit:** I initially missed the part about squashing commits into one commit in the Discourse contribution guidelines, but thought I would do that here. Should we follow that practice in Discourse API too? If not, I won't do that from now on.
