### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 2.0.0
+script: 'bundle exec rake test'


### PR DESCRIPTION
Discourse uses Travis, so it seems that this project should use it as well. I like having it there as a protection against forgetting to double-check that all tests passed before I push.

I based the Travis config on the Discourse one, in that I only included support for Ruby 2.0.0.
