### PR TITLE
Fixed issue with user resource returning 404 error. Should get from /use...

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -6,7 +6,7 @@ module DiscourseApi
       end
 
       def user(username, *args)
-        response = get("/user/#{username}.json", args)
+        response = get("/users/#{username}.json", args)
         response[:body]['user']
       end
 

--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -9,12 +9,12 @@ describe DiscourseApi::API::Users do
 
   describe "#user" do
     before do
-      stub_get("http://localhost/user/test_user.json").to_return(body: fixture("user.json"), headers: { content_type: "application/json" })
+      stub_get("http://localhost/users/test_user.json").to_return(body: fixture("user.json"), headers: { content_type: "application/json" })
     end
 
     it "requests the correct resource" do
       subject.user("test_user")
-      expect(a_get("http://localhost/user/test_user.json")).to have_been_made
+      expect(a_get("http://localhost/users/test_user.json")).to have_been_made
     end
 
     it "returns the requested user" do


### PR DESCRIPTION
This patch fixes an issue with the path of the REST request for a user. It should be `/users/#{username}.json`, not `/user/...`

Thanks!

Leo
