### PR TITLE
update API to handle CSRF token

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -15,7 +15,7 @@ module DiscourseApi
       end
 
       def update_avatar(username, file)
-        put("/users/#{username}/preferences/avatar", { api_username: username, file: file, api_key: api_key })
+        post("/users/#{username}/preferences/avatar", { api_username: username, file: file, api_key: api_key }, csrf_token: true)
       end
 
       def update_email(username, email)

--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -70,7 +70,7 @@ module DiscourseApi
       if opts[:csrf_token]
         token, session = get_token_and_session
         connection.headers['Cookie'] = session
-        params.merge(authenticity_token: token)
+        params.merge!(authenticity_token: token)
       end
       response = connection.send(method.to_sym, path, params)
       response.env


### PR DESCRIPTION
Hi Sam, 

since a few API calls were not working I updated them. The main improvement is that now it's possible to request the CSRF token, set the session and use them for protected requests. 

Andrea
