### PR TITLE
disable web requests, but allow localhost

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
   end
 end
 
-WebMock.disable_net_connect!
+WebMock.disable_net_connect!(:allow_localhost => true)
 
 def a_delete(path)
   a_request(:delete, path)


### PR DESCRIPTION
I added `:allow_localhost => true` to WebMock because I was getting this error when I was trying to run my tests:

DiscourseApi::API::Topics#latest_topics returns the requested topics
     Failure/Error: topics = subject.latest_topics
     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled.

This fix allows localhost connections but keeps any external connections disabled. See: https://github.com/bblimke/webmock#external-requests-can-be-disabled-while-allowing-localhost
