### PR TITLE
Fix log_out test

### DIFF
--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -120,7 +120,7 @@ describe DiscourseApi::API::Users do
     end
 
     it "Raises API Error" do
-      expect{subject.log_out(90)}.to raise_error DiscourseApi::ApiError
+      expect{subject.log_out(90)}.to raise_error DiscourseApi::Error
     end
   end
 end


### PR DESCRIPTION
Looks like the log_out test was failing because I was checking for the
wrong exception type.
