### PR TITLE
Fix bad update_username test

### DIFF
--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -75,17 +75,13 @@ describe DiscourseApi::API::Users do
     end
 
     it "makes the put request" do
-      subject.api_key = 'test_d7fd0429940'
-      subject.api_username = 'test_user'
       subject.update_username("fake_user", "fake_user_2")
       expect(a_put("http://localhost:3000/users/fake_user/preferences/username?api_key=test_d7fd0429940&api_username=test_user")).to have_been_made
     end
 
-    it "returns success" do
-      subject.api_key = 'test_d7fd0429940'
-      subject.api_username = 'test_user'
+    it "returns the updated username" do
       response = subject.update_username("fake_user", "fake_user_2")
-      expect(response[:body]['success']).to be_truthy
+      expect(response[:body]['username']).to eq('fake_user_2')
     end
   end
 

--- a/spec/fixtures/user_update_username.json
+++ b/spec/fixtures/user_update_username.json
@@ -1,3 +1,4 @@
 {
-  "success": true
+  "id": 7,
+  "username": "fake_user_2"
 }


### PR DESCRIPTION
The update_username test was checking for "success: true" json response
from the server, but the server was returning an empty json body. I
updated the server json response in [PR discourse/discourse #3035](https://github.com/discourse/discourse/pull/3035) to return the updated username.

The following changes were made:
- check that the updated username is returned
- update fixture to return the updated username
- remove redundant api_key and api_username
