### PR TITLE
avoid certificate errors for HTTPS endpoints

### DIFF
--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -41,11 +41,12 @@ module DiscourseApi
 
     def connection_options
       @connection_options ||= {
-          url: @host,
-          headers: {
-              accept: 'application/json',
-              user_agent: user_agent,
-          }
+        url: @host,
+        headers: {
+          accept: 'application/json',
+          user_agent: user_agent,
+        },
+        ssl: {verify: false}
       }
     end
 


### PR DESCRIPTION
Otherwise API calls will fail with

```
DiscourseApi::Error: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
```
