### PR TITLE
This fixes the create_group method to remove the root element

### DIFF
--- a/lib/discourse_api/api/groups.rb
+++ b/lib/discourse_api/api/groups.rb
@@ -6,7 +6,7 @@ module DiscourseApi
                   .required(:name)
                   .default(visible: true)
                   .to_h
-        post("/admin/groups", group: args)
+        post("/admin/groups", args)
       end
 
       def groups

--- a/spec/discourse_api/api/groups_spec.rb
+++ b/spec/discourse_api/api/groups_spec.rb
@@ -23,7 +23,7 @@ describe DiscourseApi::API::Groups do
       stub_post("http://localhost:3000/admin/groups?api_key=test_d7fd0429940&api_username=test_user")
       subject.create_group(name: "test_group")
       expect(a_post("http://localhost:3000/admin/groups?api_key=test_d7fd0429940&api_username=test_user").
-              with(body: {group: {name: "test_group", visible: "true"}})
+              with(body: {name: "test_group", visible: "true"})
             ).to have_been_made
     end
 


### PR DESCRIPTION
See https://meta.discourse.org/t/discourse-add-group-api/25571 for the discussion of this.