### PR TITLE
Update SSO params to respect missing parameters

### DIFF
--- a/lib/discourse_api/api/sso.rb
+++ b/lib/discourse_api/api/sso.rb
@@ -8,6 +8,9 @@ module DiscourseApi
         sso.username = params[:username]
         sso.email = params[:email]
         sso.external_id = params[:external_id]
+        sso.suppress_welcome_message = params[:suppress_welcome_message] === true
+        sso.avatar_url = params[:avatar_url]
+        sso.avatar_force_update = params[:avatar_force_update] === true
         post("/admin/users/sync_sso/", sso.payload)
       end
     end


### PR DESCRIPTION
sync_sso should now also support :avatar_url, :avatar_force_update, and :suppress_welcome_message.

I have also brought DiscourseApi::SingleSignOn up to date with the version at https://github.com/discourse/discourse/blob/master/lib/single_sign_on.rb to support the parameters locally.