### PR TITLE
FIX: disposable invite token example was returning undefined method error

### DIFF
--- a/examples/disposable_invite_tokens.rb
+++ b/examples/disposable_invite_tokens.rb
@@ -9,11 +9,10 @@ client.api_username = "YOUR_USERNAME"
 
 # fetch email-less invite tokens
 invite_tokens = client.disposable_tokens(username: "eviltrout", quantity: 5, group_names: "security,support")
-invite_tokens_array = invite_tokens.body
 
 # write to CSV file
 CSV.open(File.expand_path("../invite_tokens.csv", __FILE__), "w") do |csv|
-  invite_tokens_array.each do |value|
+  invite_tokens.each do |value|
     csv << [value]
   end
 end


### PR DESCRIPTION
[reported here](https://meta.discourse.org/t/generating-disposable-invite-tokens/17563/6?u=techapj)