### PR TITLE
Lock to Faraday minor version

### DIFF
--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "0.9.0"
+  spec.add_dependency "faraday", "~>0.9.0"
   spec.add_dependency "faraday_middleware", "~> 0.9"
   spec.add_dependency "rack", "~> 1.5"
   spec.add_dependency "dotenv", "~> 1.0"


### PR DESCRIPTION
We are using the gem in a project that uses a later version of Faraday so we're having Gemfile version conflicts.  The pull request allows patches to Faraday, which is probably a good idea for other reasons as well.