### PR TITLE
Added activesupport gem to gemspec, required activesupport/all in spec h...

### DIFF
--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware", "~> 0.9"
   spec.add_dependency "rack", "~> 1.5"
   spec.add_dependency "dotenv", "~> 1.0"
+  spec.add_dependency "activesupport", "~> 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "10.3.2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'active_support/all'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
Hi,
running rspec gave me:
lib/discourse_api/single_sign_on.rb:11:in `<class:SingleSignOn>': undefined method `minutes' for 10:Fixnum (NoMethodError

So I added activesupport to the gemspec and required activesupport/all in the spec_helper.
Works for me local and in CircleCI.

