### PR TITLE
dotenv 2.0, development dependency

### DIFF
--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "~>0.9.0"
   spec.add_dependency "faraday_middleware", "~> 0.9"
   spec.add_dependency "rack", "~> 1.5"
-  spec.add_dependency "dotenv", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "10.3.2"
@@ -31,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard", "~> 2.6"
   spec.add_development_dependency "rb-inotify", "~> 0.9"
   spec.add_development_dependency "simplecov", "~> 0.9"
+  spec.add_development_dependency "dotenv", "~> 1.0"
 end

--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard", "~> 2.6"
   spec.add_development_dependency "rb-inotify", "~> 0.9"
   spec.add_development_dependency "simplecov", "~> 0.9"
-  spec.add_development_dependency "dotenv", "~> 1.0"
+  spec.add_development_dependency "dotenv", ">= 1.0", "< 3.0"
 end


### PR DESCRIPTION
`discourse_api` specifies `dotenv ~> 1.0` as a runtime dependency. This is a problem when applications bundling `dotenv 2.0` attempt to also bundle `discourse_api`. `dotenv 2.0.0` was released Mar 5, 2015.

Firstly, I've extended the version spec from `~> 1.0` (effectively `>= 1.0, < 2.0`) to `>= 1.0, < 3.0`, thus permitting v2.x which [has no notable breaking changes](https://github.com/bkeepers/dotenv/blob/master/Changelog.md#200---mar-5-2015) that I can see.

Secondly, I don't think an API client library should be declaring `dotenv` as a runtime dependency at all, so I've made it a development dependency. This commit can be omitted if anybody disagrees with that.