### PR TITLE
Removed require 'dotenv' since it's not used (?).

### DIFF
--- a/examples/groups.rb
+++ b/examples/groups.rb
@@ -1,7 +1,9 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require File.expand_path('../../lib/discourse_api', __FILE__)
 
+require 'dotenv'
 Dotenv.load
+
 client = DiscourseApi::Client.new
 
 response = client.create_group(name: "engineering_team")

--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -1,4 +1,3 @@
-require 'dotenv'
 require 'faraday'
 require 'faraday_middleware'
 require 'json'

--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -39,9 +39,7 @@ module DiscourseApi
     include DiscourseApi::API::ApiKey
     include DiscourseApi::API::Backups
 
-    def initialize(host = ENV["DISCOURSE_URL"],
-                   api_key = ENV["DISCOURSE_API_KEY"],
-                   api_username = ENV["DISCOURSE_USERNAME"])
+    def initialize(host, api_key = nil, api_username = nil)
       raise ArgumentError, 'host needs to be defined' if host.nil? || host.empty?
       @host         = host
       @api_key      = api_key


### PR DESCRIPTION
I had a problem with discourse_api gem on a new Rails app -
my app just crashed with this error after I added the gem to my Gemfile:
```
/Users/user/.rvm/gems/ruby-2.2.2/gems/discourse_api-0.4.3/lib/discourse_api/client.rb:1:in `require': cannot load such file -- dotenv (LoadError)
```

I think it's because dotenv is a development dependency in gemspec,
yet we have a require 'dotenv' in client.rb. It's never loaded by
bundler when the gem is just added to a gem file, so the app crashes.

I don't see it being used in client.rb, so I've deleted it.
It's used in examples/groups.rb so I've added the require there.

I'm not sure if we need dotenv at all, can someone comment on it?