### PR TITLE
Adding permissions to create a category

### DIFF
--- a/lib/discourse_api/api/categories.rb
+++ b/lib/discourse_api/api/categories.rb
@@ -2,10 +2,11 @@ module DiscourseApi
   module API
     module Categories
       # :color and :text_color are RGB hexadecimal strings
+      # :permissions is a hash with the group name and permission_type which is an integer 1 = Full 2 = Create Post 3 = Read Only
       def create_category(args)
         args = API.params(args)
                   .required(:name, :color, :text_color)
-                  .optional(:description)
+                  .optional(:description, :permissions)
                   .default(parent_category_id: nil)
         response = post("/categories", args)
         response['category']

--- a/spec/discourse_api/api/categories_spec.rb
+++ b/spec/discourse_api/api/categories_spec.rb
@@ -66,4 +66,15 @@ describe DiscourseApi::API::Categories do
       expect(topics).to be_an Array
     end
   end
+
+  describe "creates a new category" do
+    it "returns success" do
+      subject.api_key = 'test_d7fd0429940'
+      subject.api_username = 'test_user'
+      # category name is random letters to avoid category name taken error
+      response = subject.create_category(name: ('a'..'z').to_a.shuffle[0,8].join, color: "283890",
+        text_color: "FFFFFF", description: "This is a description", permissions: {"group_1" => 1, "admins" => 1})
+      expect(response).to be_a Hash
+    end
+  end  
 end


### PR DESCRIPTION
In order to make a category private to a certain group upon creation, I have am adding permissions as an optional parameter.  You will need to have the group name and a permission_type.  I am also adding a scenario to test creating a category.

Permission types are:
    1 = Full
    2 = Create Post
    3 = Read Only

Example use:

response = @client.create_category(
	name: “CategoryName”,
	color: "283890"
        text_color: "FFFFFF",
	description: "This is a description",
	permissions: {"group_1" => 1, "admins" => 1}
)