### PR TITLE
Add support for getting category topics by page

### DIFF
--- a/examples/category.rb
+++ b/examples/category.rb
@@ -10,3 +10,12 @@ puts client.categories()
 
 # get sub categories for parent category with id 2
 puts client.categories(parent_category_id: 2)
+
+# List topics in a category
+category_topics = client.category_latest_topics(category_slug: "test-category")
+puts category_topics
+
+# List topics in a category paged
+category_topics_paged = client.category_latest_topics(category_slug: "test-category", page: "5")
+puts category_topics_paged
+

--- a/lib/discourse_api/api/categories.rb
+++ b/lib/discourse_api/api/categories.rb
@@ -2,8 +2,9 @@ module DiscourseApi
   module API
     module Categories
       # :color and :text_color are RGB hexadecimal strings
-      # :permissions is a hash with the group name and permission_type which is an integer 1 = Full 2 = Create Post 3 = Read Only
-      def create_category(args)
+      # :permissions is a hash with the group name and permission_type which is
+      # an integer 1 = Full 2 = Create Post 3 = Read Only
+      def create_category(args={})
         args = API.params(args)
                   .required(:name, :color, :text_color)
                   .optional(:description, :permissions)
@@ -17,8 +18,16 @@ module DiscourseApi
         response[:body]['category_list']['categories']
       end
 
-      def category_latest_topics(category_slug)
-        response = get("/category/#{category_slug}/l/latest.json")
+      def category_latest_topics(args={})
+        params = API.params(args)
+                    .required(:category_slug)
+                    .optional(:page).to_h
+        url = "/c/#{params[:category_slug]}/l/latest.json"
+        if params.include?(:page)
+          puts params[:page]
+          url = "#{url}?page=#{params[:page]}"
+        end 
+        response = get(url)
         response[:body]['topic_list']['topics']
       end
 

--- a/lib/discourse_api/api/params.rb
+++ b/lib/discourse_api/api/params.rb
@@ -6,6 +6,7 @@ module DiscourseApi
 
     class Params
       def initialize(args)
+        raise ArgumentError.new("Required to be initialized with a Hash") unless args.is_a? Hash
         @args = args
         @required = []
         @optional = []

--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -4,7 +4,7 @@ module DiscourseApi
       # :category OPTIONAL name of category, not ID
       # :skip_validations OPTIONAL boolean
       # :auto_track OPTIONAL boolean
-      def create_topic(args)
+      def create_topic(args={})
         args = API.params(args)
                   .required(:title, :raw)
                   .optional(:skip_validations, :category, :auto_track)

--- a/spec/discourse_api/api/categories_spec.rb
+++ b/spec/discourse_api/api/categories_spec.rb
@@ -29,12 +29,12 @@ describe DiscourseApi::API::Categories do
 
   describe '#category_latest_topics' do
     before do
-      stub_get("http://localhost:3000/category/category-slug/l/latest.json?api_key=test_d7fd0429940&api_username=test_user")
+      stub_get("http://localhost:3000/c/category-slug/l/latest.json?api_key=test_d7fd0429940&api_username=test_user")
         .to_return(body: fixture("category_latest_topics.json"), headers: { content_type: "application/json" })
     end
 
     it "returns the latest topics in a category" do
-      latest_topics = subject.category_latest_topics('category-slug')
+      latest_topics = subject.category_latest_topics(category_slug: 'category-slug')
       expect(latest_topics).to be_an Array
     end
   end


### PR DESCRIPTION
- Be able to get topics in a category by page
- `category_latest_topics` now takes a params hash instead of a string
- Added example
- changed url to be '/c/' instead of '/category/'
- Updated test to use new url and params hash