### PR TITLE
fetch a group of posts that belong to a topic

### DIFF
--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -42,6 +42,18 @@ module DiscourseApi
       def delete_topic(id)
         delete("/t/#{id}.json")
       end
+
+      def topic_posts(topic_id, post_ids=[])
+        url = "/t/#{topic_id}/posts.json"
+        if posts_ids.count > 0
+          url << '?'
+          post_ids.each do |id|
+            url << "post_ids[]=#{id}&"
+          end 
+        end
+        response = get(url) 
+        response[:body]
+      end
     end
   end
 end


### PR DESCRIPTION
Added new method for fetching a chunk of posts that belong to a topic.

Currently if you called `client.topic('topic_id')` you would only get
back ~20 posts.

Now you can call `client.topic_posts('topic_id', post_ids)` to get all
the posts you specify in the `post_ids` array.