### PR TITLE
[FIX] API::Params will not work correctly when both optional and defaults are specified.

### DIFF
--- a/lib/discourse_api/api/params.rb
+++ b/lib/discourse_api/api/params.rb
@@ -38,18 +38,12 @@ module DiscourseApi
           raise ArgumentError.new("#{k} is required but not specified") unless h[k]
         end
 
-        h =
-          if @optional.length == 0
-            @args.dup
-          else
-            @optional.each do |k|
-              h[k] = @args[k] if @args.include?(k)
-            end
-            h
-          end
+        @optional.each do |k|
+          h[k] = @args[k] if @args.include?(k)
+        end
 
         @defaults.each do |k,v|
-          h[k] = v unless h.key?(k)
+          @args.key?(k) ? h[k] = @args[k] : h[k] = v
         end
 
         h

--- a/spec/discourse_api/api/params_spec.rb
+++ b/spec/discourse_api/api/params_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe DiscourseApi::API::Params do
   def params_for(h)
-    DiscourseApi::API::Params.new(h).required(:r1).optional(:o1, :o2)
+    DiscourseApi::API::Params.new(h).required(:r1).optional(:o1, :o2).default(d1: "default")
   end
 
   it "should raise on missing required params" do
@@ -15,6 +15,18 @@ describe DiscourseApi::API::Params do
 
   it "should include optional params if provided but blank" do
     expect(params_for({r1: "test", o2: nil}).to_h).to include(:o2)
+  end
+
+  it "should include default params when defined but not provided" do
+    expect(params_for({r1: "test"}).to_h).to include(d1: "default")
+  end
+
+  it "should include default params when defined and provided" do
+    expect(params_for({r1: "test", d1: "override"}).to_h).to include(d1: "override")
+  end
+
+  it "should include optional and default params when defined and provided" do
+    expect(params_for({r1: "test", o1: "optional", d1: "override"}).to_h).to include(o1: "optional", d1: "override")
   end
 
 end


### PR DESCRIPTION
### Issue
The `to_h` method for `API::Params` does not work correctly when both the `optional` and `default` methods are called.

### Example
When trying to create a category via `create_category`, it is defined as allowing:

           args = API.params(args)
                  .required(:name, :color, :text_color)
                  .optional(:description, :permissions)
                  .default(parent_category_id: nil)

If you specify a `parent_category_id` in the original `args`, it will be overwritten with `nil` when the `to_h` method is called to perform the request.

### `to_h`
The `to_h` method processed the `optional` and `default` params by:

        h =
          if @optional.length == 0
            @args.dup
          else
            @optional.each do |k|
              h[k] = @args[k] if @args.include?(k)
            end
            h
          end

        @defaults.each do |k,v|
          h[k] = v unless h.key?(k)
        end

If optional values are specified, any default keys present in `args` are never set on `h` since they were only carried through via `h = @args.dup`.  In turn, any default keys would be forcibly defaulted regardless of the presence in `args` as `h` will not contain the key.

### Solution
I'm not sure if it is an oversimplification, but this PR has the code that worked for our project in case anyone is hung up on this.  It simply checks to see if the `args` contains the defaulted key.  If so, it uses that value - otherwise, it defaults to the value specified in the original `default` call.