### PR TITLE
Add ability for public, unauthed users

### DIFF
--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -105,8 +105,10 @@ module DiscourseApi
         # Use Faraday's default HTTP adapter
         conn.adapter Faraday.default_adapter
         #pass api_key and api_username on every request
-        conn.params['api_key'] = api_key
-        conn.params['api_username'] = api_username
+        unless api_username.nil?
+          conn.params['api_key'] = api_key
+          conn.params['api_username'] = api_username
+        end
       end
     end
 


### PR DESCRIPTION
Currently the gem only allows requests with both an API key and username present. Even though, they can be `nil` by default, attempting to access a public route in Discourse such as `/categories.json` will raise an authentication error.

This change will allow public access of routes such as categories or latest topics without compromising the security of actions like making a new post  or user-specific visibility settings. It's virtually identical to a direct `curl` request against a Discourse app.