### PR TITLE
Add post actions such as likes and flags

### DIFF
--- a/examples/post_action.rb
+++ b/examples/post_action.rb
@@ -1,0 +1,25 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require File.expand_path('../../lib/discourse_api', __FILE__)
+
+client = DiscourseApi::Client.new("http://localhost:3000")
+client.api_key = "YOUR_API_KEY"
+client.api_username = "YOUR_USERNAME"
+
+# Post Action Type IDs
+# 1 - Bookmark
+# 2 - Like
+# 3 - Flag: Off-topic
+# 4 - Flag: Inappropriate
+# 5 - Vote
+# 6 - Notify User
+# 7 - Flag - Notify Moderators
+# 8 - Flag - Spam
+
+# Like a post
+client.create_post_action(post_id: 1, post_action_type_id: 2)
+
+# Flag a topic as spam
+client.create_topic_action(topic_id: 1, post_action_type_id: 8)
+
+# Unlike a post
+client.destroy_post_action(post_id: 1, post_action_type_id: 2)

--- a/lib/discourse_api/api/posts.rb
+++ b/lib/discourse_api/api/posts.rb
@@ -7,6 +7,12 @@ module DiscourseApi
         post("/posts", args)
       end
 
+      def create_post_action(args)
+        args = API.params(args)
+                   .required(:post_id, :post_action_type_id)
+        post("/post_actions", args.to_h.merge(flag_topic: false))
+      end
+
       def get_post(id, args = {})
         args = API.params(args)
                   .optional(:version)
@@ -20,6 +26,16 @@ module DiscourseApi
 
       def edit_post(id, raw)
         put("/posts/#{id}", post: {raw: raw})
+      end
+
+      def destroy_post_action(post_id:, post_action_type_id:)
+        delete("/post_actions/#{post_id}.json", post_action_type_id: post_action_type_id)
+      end
+
+      # This will need to be updated when Discourse 1.5 is released
+      def post_action_users(post_id:, post_action_type_id:)
+        response = get("/post_actions/users.json", {id: post_id, post_action_type_id: post_action_type_id})
+        response[:body]
       end
     end
   end

--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -11,6 +11,12 @@ module DiscourseApi
         post("/posts", args.to_h)
       end
 
+      def create_topic_action(args)
+        args = API.params(args)
+                   .required(:topic_id, :post_action_type_id)
+        post("/post_actions", args.to_h.merge(flag_topic: true))
+      end
+
       def latest_topics(params={})
         response = get('/latest.json', params)
         response[:body]['topic_list']['topics']


### PR DESCRIPTION
This PR adds post actions, which include likes and the different types of flags based on the ID that's passed in. They can be created, destroyed and retrieved for a specific post along with the user that committed the action.

Thoughts? Feedback much appreciated!