### PR TITLE
FIX: Use id instead of topic_id or post_id in params for post actions

### DIFF
--- a/examples/post_action.rb
+++ b/examples/post_action.rb
@@ -16,10 +16,10 @@ client.api_username = "YOUR_USERNAME"
 # 8 - Flag - Spam
 
 # Like a post
-client.create_post_action(post_id: 1, post_action_type_id: 2)
+client.create_post_action(id: 2, post_action_type_id: 2)
 
 # Flag a topic as spam
-client.create_topic_action(topic_id: 1, post_action_type_id: 8)
+client.create_topic_action(id: 1, post_action_type_id: 8)
 
 # Unlike a post
-client.destroy_post_action(post_id: 1, post_action_type_id: 2)
+client.destroy_post_action(id: 3, post_action_type_id: 2)

--- a/lib/discourse_api/api/posts.rb
+++ b/lib/discourse_api/api/posts.rb
@@ -9,7 +9,7 @@ module DiscourseApi
 
       def create_post_action(args)
         args = API.params(args)
-                   .required(:post_id, :post_action_type_id)
+                   .required(:id, :post_action_type_id)
         post("/post_actions", args.to_h.merge(flag_topic: false))
       end
 

--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -13,7 +13,7 @@ module DiscourseApi
 
       def create_topic_action(args)
         args = API.params(args)
-                   .required(:topic_id, :post_action_type_id)
+                   .required(:id, :post_action_type_id)
         post("/post_actions", args.to_h.merge(flag_topic: true))
       end
 


### PR DESCRIPTION
I made a derp and wrote `post_id` and `topic_id` instead of `id` for the new post action methods. The Discourse app requires the `id` as a parameter for the post actions controller. Sorry!