### PR TITLE
Handle requests w/leading slashes throughout api for hosts with faraday configured url prefixes

### DIFF
--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -41,11 +41,12 @@ module DiscourseApi
     include DiscourseApi::API::Backups
     include DiscourseApi::API::Dashboard
 
-    def initialize(host, api_key = nil, api_username = nil)
+    def initialize(host, api_key = nil, api_username = nil, include_prefix = nil)
       raise ArgumentError, 'host needs to be defined' if host.nil? || host.empty?
       @host         = host
       @api_key      = api_key
       @api_username = api_username
+      @include_prefix = include_prefix #https://github.com/lostisland/faraday/issues/293
     end
 
     def connection_options
@@ -116,6 +117,7 @@ module DiscourseApi
       unless Hash === params
         params = params.to_h if params.respond_to? :to_h
       end
+      path.slice!(0) if @include_prefix
       response = connection.send(method.to_sym, path, params)
       handle_error(response)
       response.env


### PR DESCRIPTION
Issue is articulated here: https://github.com/lostisland/faraday/issues/293

Issue:
conn = Faraday.new(:url => 'http://example.com/api')
conn.get '/index' #=> GET http://example.com/index

Solution:
conn.get 'index' (remove leading slash)

Example in discourse_api get('categories.json', params) instead of get('/categories.json')

In most cases clients will not experience this as I assume requests from domain ('http://example.com/') would be desired. However, if that is not the case faraday seems to strip url prefix when request has a leading slash. 

I altered client.rb in a way that this **won't impact** any existing discourse_api users, but will not allow the ability to bypass this faraday quirk if they pass fourth argument upon initialization.
