### PR TITLE
Allow topic-creation-times to be edited.

### DIFF
--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -4,10 +4,11 @@ module DiscourseApi
       # :category OPTIONAL name of category, not ID
       # :skip_validations OPTIONAL boolean
       # :auto_track OPTIONAL boolean
+      # :created_at OPTIONAL seconds since epoch.
       def create_topic(args={})
         args = API.params(args)
                   .required(:title, :raw)
-                  .optional(:skip_validations, :category, :auto_track)
+                  .optional(:skip_validations, :category, :auto_track, :created_at)
         post("/posts", args.to_h)
       end
 

--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -17,6 +17,11 @@ module DiscourseApi
         post("/post_actions", args.to_h.merge(flag_topic: true))
       end
 
+      # timestamp is seconds past the epoch.
+      def edit_topic_timestamp(topic_id,timestamp)
+        put("/t/#{topic_id}/change-timestamp", { timestamp: timestamp })
+      end
+
       def latest_topics(params={})
         response = get('/latest.json', params)
         response[:body]['topic_list']['topics']


### PR DESCRIPTION
This is a missing piece of functionality which is the best current way to set the timestamp upon a new topic, as it cannot be specified when a topic is created.

For reference please see:

* https://meta.discourse.org/t/set-the-date-of-a-new-topic-via-the-api/43308