### PR TITLE
Add a destination parameter to download_backup

### DIFF
--- a/examples/backups.rb
+++ b/examples/backups.rb
@@ -15,4 +15,4 @@ puts client.create_backup()
 puts client.restore_backup("backup_file_name.tar.gz")
 
 # download backup
-puts client.download_backup("backup_file_name.tar.gz")
+puts client.download_backup("backup_file_name.tar.gz", "/tmp/")

--- a/lib/discourse_api/api/backups.rb
+++ b/lib/discourse_api/api/backups.rb
@@ -14,10 +14,10 @@ module DiscourseApi
         post("/admin/backups/#{file_name}/restore")
       end
 
-      def download_backup(file_name)
+      def download_backup(file_name, destination)
         response = get("/admin/backups/#{file_name}")
         # write file
-        File.open('examples/backup.tar.gz', 'wb') { |fp| fp.write(response.body) }
+        File.open("#{destination}/#{file_name}", 'wb') { |fp| fp.write(response.body) }
       end
     end
   end


### PR DESCRIPTION
THe default download is not very useful and likely not working
out of the box most of the time.