### PR TITLE
You should be able to set the username of a topic when POSTing a new topic to the API

### DIFF
--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -8,7 +8,7 @@ module DiscourseApi
       def create_topic(args={})
         args = API.params(args)
                   .required(:title, :raw)
-                  .optional(:skip_validations, :category, :auto_track, :created_at)
+                  .optional(:skip_validations, :category, :auto_track, :created_at, :api_username)
         post("/posts", args.to_h)
       end
 


### PR DESCRIPTION
Currently the username is only set via the client.api_username.  I suspect this is an old carryover from when the Discourse API had both an api_key and api_username?  Either way, you should be able to POST new topics from multiple users and you shouldn't have to create new client connections each time.  In a perfect world the param for create_topic would be 'username' and not 'api_username', but that param is controlled by the Discourse API ¯\_(ツ)_/¯