### PR TITLE
Allow for changing of topic statuses

### DIFF
--- a/examples/change_topic_status.rb
+++ b/examples/change_topic_status.rb
@@ -1,0 +1,33 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require File.expand_path('../../lib/discourse_api', __FILE__)
+
+client = DiscourseApi::Client.new("http://localhost:3000")
+client.api_key = "YOUR_API_KEY"
+client.api_username = "YOUR_USERNAME"
+
+response = client.create_topic(
+    category: "Boing Boing",
+    skip_validations: true,
+    auto_track: false,
+    title: "Concert Master: A new way to choose",
+    raw: "This is the raw markdown for my post"
+)
+
+# get topic_id and topic_slug from response
+topic_id = response['topic_id']
+topic_slug = response['topic_slug']
+
+
+##
+# available options (guessing from reading discourse source)
+# status can be: ['autoclose', 'closed', 'archived', 'disabled', 'visible']
+# enabled can be: [true, false]
+##
+
+# lock topic (note: api_username determines user that is performing action)
+params = {status: 'closed', enabled: true, api_username: "YOUR USERNAME/USERS USERNAME"}
+client.change_topic_status(topic_slug, topic_id, params)
+
+# unlock topic (note: api_username determines user that is performing action)
+params = {status: 'closed', enabled: false, api_username: "YOUR USERNAME/USERS USERNAME"}
+client.change_topic_status(topic_slug, topic_id, params)

--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -41,6 +41,13 @@ module DiscourseApi
         put("/t/#{topic_id}.json", { topic_id: topic_id, category_id: category_id })
       end
 
+      def change_topic_status(topic_slug, topic_id, params={})
+        params = API.params(params)
+                     .required(:status, :enabled)
+                     .optional(:api_username)
+        put("/t/#{topic_slug}/#{topic_id}/status", params.to_h)
+      end
+
       def topic(id, params={})
         response = get("/t/#{id}.json", params)
         response[:body]


### PR DESCRIPTION
API should support closing/opening, archiving/unarchiving, etc, a topic.  I added an example and put in some statuses but I may not have captured them all.