### PR TITLE
Update Posts#post_action_users for 1.5 endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 2.2.3
+  - 2.2.5
   - 2.3.1
 script: 'bundle exec rake test'

--- a/lib/discourse_api/api/posts.rb
+++ b/lib/discourse_api/api/posts.rb
@@ -32,9 +32,8 @@ module DiscourseApi
         delete("/post_actions/#{post_id}.json", post_action_type_id: post_action_type_id)
       end
 
-      # This will need to be updated when Discourse 1.5 is released
       def post_action_users(post_id, post_action_type_id)
-        response = get("/post_actions/users.json", {id: post_id, post_action_type_id: post_action_type_id})
+        response = get("/post_action_users.json", {id: post_id, post_action_type_id: post_action_type_id})
         response[:body]
       end
     end

--- a/spec/discourse_api/api/posts_spec.rb
+++ b/spec/discourse_api/api/posts_spec.rb
@@ -26,4 +26,16 @@ describe DiscourseApi::API::Posts do
     end
   end
 
+  describe "#post_action_users" do
+    before do
+      stub_get("http://localhost:3000/post_action_users.json?api_key=test_d7fd0429940&api_username=test_user&id=11&post_action_type_id=2").to_return(body: fixture("post_action_users.json"), headers: { content_type: "application/json" })
+    end
+
+    it "fetches post_action_users" do
+      post_action_users = client.post_action_users(11, 2)
+      expect(post_action_users).to be_a Hash
+      expect(post_action_users["post_action_users"][0]["id"]).to eq(1286)
+    end
+  end
+
 end

--- a/spec/fixtures/post_action_users.json
+++ b/spec/fixtures/post_action_users.json
@@ -1,0 +1,18 @@
+{
+  "post_action_users":  [
+    {
+      "id": 1286,
+      "username": "john_smith",
+      "avatar_template": "/user_avatar/domain/john_smith/size/1609_1.png",
+      "post_url": null,
+      "username_lower": "john_smith"
+    },
+    {
+      "id": 1,
+      "username": "jane_smith",
+      "avatar_template": "/user_avatar/domain/jane_smith/size/17_1.png",
+      "post_url": null,
+      "username_lower": "jane_smith"
+    }
+  ]
+}


### PR DESCRIPTION
- Add a unit test and fixture for post_action_users
- Add a fixture for post_action_users
  - Fixture taken from a Discuss 1.6.1 live instance (text values changed)
- Tested locally against current (9/1) master branch on discourse/discourse