### PR TITLE
Add wrappers for admin/users/{id}/[suspend|unsuspend] endpoints

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -80,6 +80,14 @@ module DiscourseApi
         response = get("/users/by-external/#{external_id}")
         response[:body]['user']
       end
+
+      def suspend(user_id, days, reason)
+        put("/admin/users/#{user_id}/suspend", {duration: days, reason: reason})
+      end
+
+      def unsuspend(user_id)
+        put("/admin/users/#{user_id}/unsuspend")
+      end
     end
   end
 end

--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -224,4 +224,32 @@ describe DiscourseApi::API::Users do
       expect(user['id']).to eq 1
     end
   end
+
+  describe "#suspend" do
+    before do
+      url = "http://localhost:3000/admin/users/11/suspend?api_key=test_d7fd0429940&api_username=test_user"
+      stub_put(url).to_return(body: '', status: 200)
+    end
+
+    it "makes the correct put request" do
+      result = subject.suspend(11, 1, "no reason")
+      url = "http://localhost:3000/admin/users/11/suspend?api_key=test_d7fd0429940&api_username=test_user"
+      expect(a_put(url)).to have_been_made
+      expect(result.status).to eq(200)
+    end
+  end
+
+  describe "#unsuspend" do
+    before do
+      url = "http://localhost:3000/admin/users/11/unsuspend?api_key=test_d7fd0429940&api_username=test_user"
+      stub_put(url).to_return(body: '', status: 200)
+    end
+
+    it "makes the correct put request" do
+      result = subject.unsuspend(11)
+      url = "http://localhost:3000/admin/users/11/unsuspend?api_key=test_d7fd0429940&api_username=test_user"
+      expect(a_put(url)).to have_been_made
+      expect(result.status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
Tested on Discourse 1.6.4 (latest stable), and those endpoints haven't changed since then on master (they've been stable since last year).

Those endpoints return empty 200s, so I didn't bother making fake fixture files with no resemblance to reality, is that ok?