### PR TITLE
Add upload post image

### DIFF
--- a/examples/upload.rb
+++ b/examples/upload.rb
@@ -1,0 +1,12 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require File.expand_path('../../lib/discourse_api', __FILE__)
+
+client = DiscourseApi::Client.new("http://localhost:3000")
+client.api_key = "YOUR_API_KEY"
+client.api_username = "YOUR_USERNAME"
+
+# Upload an image via file
+client.upload_post_image(file: 'grumpy_cat.gif')
+
+# Upload an image via URL
+client.upload_post_image(url: 'https://giphy.com/grumpy_cat.gif')

--- a/lib/discourse_api/api/uploads.rb
+++ b/lib/discourse_api/api/uploads.rb
@@ -1,0 +1,13 @@
+module DiscourseApi
+  module API
+    module Uploads
+      def upload_post_image(args)
+        args = API.params(args)
+                  .optional(:file, :url)
+                  .default(type: 'composer', synchronous: true)
+                  .to_h
+        post('/uploads', args)
+      end
+    end
+  end
+end

--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -18,6 +18,7 @@ require 'discourse_api/api/email'
 require 'discourse_api/api/api_key'
 require 'discourse_api/api/backups'
 require 'discourse_api/api/dashboard'
+require 'discourse_api/api/uploads'
 
 module DiscourseApi
   class Client
@@ -40,6 +41,7 @@ module DiscourseApi
     include DiscourseApi::API::ApiKey
     include DiscourseApi::API::Backups
     include DiscourseApi::API::Dashboard
+    include DiscourseApi::API::Uploads
 
     def initialize(host, api_key = nil, api_username = nil)
       raise ArgumentError, 'host needs to be defined' if host.nil? || host.empty?

--- a/spec/discourse_api/api/uploads_spec.rb
+++ b/spec/discourse_api/api/uploads_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe DiscourseApi::API::Uploads do
+  subject { DiscourseApi::Client.new("http://localhost:3000", "test_d7fd0429940", "test_user") }
+
+  describe "#upload_post_image" do
+    before do
+      stub_post("http://localhost:3000/uploads?api_key=test_d7fd0429940&api_username=test_user").to_return(body: fixture("upload_post_image.json"), headers: { content_type: "application/json" })
+    end
+
+    it "uploads an image via URL" do
+      image = "https://meta-discourse.global.ssl.fastly.net/user_avatar/meta.discourse.org/sam/120/5243.png"
+      args = { url: image }
+      response = subject.upload_post_image(args)
+      expect(response["url"]).to eq("/uploads/default/original/1X/417e624d2453925e6c68748b9aa67637c284b5aa.jpg")
+    end
+  end
+end

--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -197,7 +197,7 @@ describe DiscourseApi::API::Users do
     end
 
     it "makes the correct put request" do
-      result = subject.grant_admin(11)
+      subject.grant_admin(11)
       url = "http://localhost:3000/admin/users/11/grant_admin?api_key=test_d7fd0429940&api_username=test_user"
       expect(a_put(url)).to have_been_made
     end

--- a/spec/fixtures/upload_post_image.json
+++ b/spec/fixtures/upload_post_image.json
@@ -1,0 +1,14 @@
+{
+  "id": 11,
+  "user_id": 1,
+  "original_filename": "grumpy_cat.gif",
+  "filesize": 86900,
+  "width": 360,
+  "height": 360,
+  "url": "/uploads/default/original/1X/417e624d2453925e6c68748b9aa67637c284b5aa.jpg",
+  "created_at": "2015-06-21T12:35:45.182Z",
+  "updated_at": "2015-06-21T12:35:45.195Z",
+  "sha1": "417e624d2453925e6c68748b9aa67637c284b5aa",
+  "origin": null,
+  "retain_hours": null
+}


### PR DESCRIPTION
This adds the ability to upload images via a file or a URL.

We needed a way to upload an image as part of a new post/topic creation. Ideally, this is called first and the URL provided will match what's returned in the newly created cooked post markup.