### PR TITLE
Add more specific errors

### DIFF
--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -129,6 +129,12 @@ module DiscourseApi
       case response.status
       when 403
         raise DiscourseApi::UnauthenticatedError.new(response.env[:body])
+      when 404, 410
+        raise DiscourseApi::NotFoundError.new(response.env[:body])
+      when 422
+        raise DiscourseApi::UnprocessableEntity.new(response.env[:body])
+      when 429
+        raise DiscourseApi::TooManyRequests.new(response.env[:body])
       end
     end
   end

--- a/lib/discourse_api/error.rb
+++ b/lib/discourse_api/error.rb
@@ -14,4 +14,13 @@ module DiscourseApi
 
   class UnauthenticatedError < StandardError
   end
+
+  class NotFoundError < StandardError
+  end
+
+  class UnprocessableEntity < StandardError
+  end
+
+  class TooManyRequests < StandardError
+  end
 end

--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -146,7 +146,7 @@ describe DiscourseApi::API::Users do
     end
 
     it "Raises API Error" do
-      expect{subject.log_out(90)}.to raise_error DiscourseApi::Error
+      expect{subject.log_out(90)}.to raise_error DiscourseApi::NotFoundError
     end
   end
 


### PR DESCRIPTION
We found that only having an unauthenticated or generic error was a bit too vague for our needs. I've added some common ones including `NotFound`, `UnprocessableEntity`, and `TooManyRequests`, which is returned when the rate limit is hit on the Discourse instance.