### PR TITLE
rack dependency loosened to permit rack v2 / Rails v5.

### DIFF
--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "faraday_middleware", "~> 0.10"
-  spec.add_dependency "rack", "~> 1.6"
+  spec.add_dependency "rack", ">= 1.6"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 11.1"


### PR DESCRIPTION
The latest [`discourse_api` v0.14.0](https://rubygems.org/gems/discourse_api/versions/0.14.0) depends on `rack ~> 1.6` while [Rails 5's `actionpack`](https://rubygems.org/gems/actionpack/versions/5.0.0.1) depends on `rack ~> 2.0`, so `discourse_api` is holding back upgrades to Rails 5. Bundler tends to resolve this by using [`discourse_api` v0.10.1](https://rubygems.org/gems/discourse_api/versions/0.10.1) (it depends on `rack >= 1.5`) which isn't a desirable resolution.

I doubt there's any changes in Rack v2.x that are incompatible with `discourse_api`; the stricter version spec came in e2d3ce7c5d2f8e663dc1539e0909547831a800a8 which doesn't mention it as a deliberate change.

This PR changes the dependency to `rack >= 1.6`, thus leaving the lower-bound unchanged but permitting newer versions including v2.x. It could be changed to `>= 1.6, < 3.0` but I don't think that adds much value; rack has a stable API and it's unlikely they'll change anything that breaks `discourse_api`.