### PR TITLE
Create private messages

### DIFF
--- a/examples/create_private_message.rb
+++ b/examples/create_private_message.rb
@@ -1,0 +1,12 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require File.expand_path('../../lib/discourse_api', __FILE__)
+
+client = DiscourseApi::Client.new("http://localhost:3000")
+client.api_key = "YOUR_API_KEY"
+client.api_username = "YOUR_USERNAME"
+
+client.create_private_message(
+  title: "Confidential: Hello World!",
+  raw: "This is the raw markdown for my private message",
+  target_usernames: ["user1", "user2"]
+)

--- a/lib/discourse_api/api/private_messages.rb
+++ b/lib/discourse_api/api/private_messages.rb
@@ -1,6 +1,18 @@
 module DiscourseApi
   module API
     module PrivateMessages
+
+      # :target_usernames REQUIRED comma separated list of usernames
+      # :category OPTIONAL name of category, not ID
+      # :created_at OPTIONAL seconds since epoch.
+      def create_private_message(args={})
+        args[:archetype] = 'private_message'
+        args = API.params(args)
+                  .required(:title, :raw, :target_usernames, :archetype)
+                  .optional(:category, :created_at, :api_username)
+        post("/posts", args.to_h)
+      end
+
       def private_messages(username, *args)
         response = get("topics/private-messages/#{username}.json", args)
         response[:body]['topic_list']['topics']

--- a/spec/discourse_api/api/private_messages_spec.rb
+++ b/spec/discourse_api/api/private_messages_spec.rb
@@ -19,4 +19,20 @@ describe DiscourseApi::API::PrivateMessages do
     end
   end
 
+  describe '#create_private_message' do
+    before do
+      stub_post("http://localhost:3000/posts?api_key=test_d7fd0429940&api_username=test_user")
+      subject.create_private_message(
+        title: "Confidential: Hello World!",
+        raw: "This is the raw markdown for my private message",
+        target_usernames: ["user1", "user2"]
+      )
+    end
+
+    it "makes a create private message request" do
+      expect(a_post("http://localhost:3000/posts?api_key=test_d7fd0429940&api_username=test_user").with(body:
+          'archetype=private_message&raw=This+is+the+raw+markdown+for+my+private+message&target_usernames%5B%5D=user1&target_usernames%5B%5D=user2&title=Confidential%3A+Hello+World%21')
+        ).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
Allows to create private messages via API as requested in #140 
API reference: http://docs.discourse.org/#tag/Topics