### PR TITLE
Add connection error handling for 500 responses

### DIFF
--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -135,6 +135,8 @@ module DiscourseApi
         raise DiscourseApi::UnprocessableEntity.new(response.env[:body])
       when 429
         raise DiscourseApi::TooManyRequests.new(response.env[:body])
+      when 500...600
+        raise DiscourseApi::Error.new(response.env[:body])
       end
     end
   end

--- a/spec/discourse_api/client_spec.rb
+++ b/spec/discourse_api/client_spec.rb
@@ -102,6 +102,13 @@ describe DiscourseApi::Client do
   end
 
   describe "#request" do
+    it "catches 500 errors" do
+      connection = instance_double(Faraday::Connection)
+      allow(connection).to receive(:get).and_return(OpenStruct.new(env: { body: 'error page html' }, status: 500))
+      allow(subject).to receive(:connection).and_return(connection)
+      expect{subject.send(:request, :get, "/test")}.to raise_error DiscourseApi::Error
+    end
+
     it "catches Faraday errors" do
       allow(subject).to receive(:connection).and_raise(Faraday::Error::ClientError.new("BOOM!"))
       expect{subject.send(:request, :get, "/test")}.to raise_error DiscourseApi::Error


### PR DESCRIPTION
When the remote server returns a 500-599 error status, the API returns an empty or string based body, breaking methods that depend on a structured response (such as `Topics#latest_topics`) in unexpected or hard-to-handle ways.

Instead, we could/should handle these with a known, consistent error code to ease handling. The changes add a case statement to the method in the base client library that parses response codes, looks for anything in the 500…600 range, and raises a DiscourseApi::Error.