### PR TITLE
Fetch sent private messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ client.sync_sso(                                #=> Synchronizes the SSO record
   email: "name@example.com",
   external_id: "2"
 )
+
+# Private messages
+client.private_messages("test_user")            #=> Gets a list of private messages received by "test_user"
+client.sent_private_messages("test_user")       #=> Gets a list of private messages sent by "test_user"
+client.create_private_message(                  #=> Creates a private messages by api_username user
+  title: "Confidential: Hello World!",
+  raw: "This is the raw markdown for my private message",
+  target_usernames: "user1,user2"
+)
+
 ```
 
 

--- a/examples/create_private_message.rb
+++ b/examples/create_private_message.rb
@@ -8,5 +8,5 @@ client.api_username = "YOUR_USERNAME"
 client.create_private_message(
   title: "Confidential: Hello World!",
   raw: "This is the raw markdown for my private message",
-  target_usernames: ["user1", "user2"]
+  target_usernames: "user1,user2"
 )

--- a/examples/sent_private_messages.rb
+++ b/examples/sent_private_messages.rb
@@ -1,0 +1,8 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require File.expand_path('../../lib/discourse_api', __FILE__)
+
+client = DiscourseApi::Client.new("http://localhost:3000")
+client.api_key = "YOUR_API_KEY"
+client.api_username = "YOUR_USERNAME"
+
+client.sent_private_messages('test_user')

--- a/lib/discourse_api/api/private_messages.rb
+++ b/lib/discourse_api/api/private_messages.rb
@@ -17,6 +17,11 @@ module DiscourseApi
         response = get("topics/private-messages/#{username}.json", args)
         response[:body]['topic_list']['topics']
       end
+
+      def sent_private_messages(username, *args)
+        response = get("topics/private-messages-sent/#{username}.json", args)
+        response[:body]['topic_list']['topics']
+      end
     end
   end
 end

--- a/spec/discourse_api/api/private_messages_spec.rb
+++ b/spec/discourse_api/api/private_messages_spec.rb
@@ -19,6 +19,22 @@ describe DiscourseApi::API::PrivateMessages do
     end
   end
 
+  describe "#sent_private_messages" do
+    before do
+      stub_get("http://localhost:3000/topics/private-messages-sent/test_user.json?api_key=test_d7fd0429940&api_username=test_user").to_return(body: fixture("private_messages.json"), headers: { content_type: "application/json" })
+    end
+
+    it "requests the correct resource" do
+      subject.sent_private_messages('test_user')
+      expect(a_get("http://localhost:3000/topics/private-messages-sent/test_user.json?api_key=test_d7fd0429940&api_username=test_user")).to have_been_made
+    end
+
+    it "returns the requested sent private messages" do
+      private_messages = subject.sent_private_messages('test_user')
+      expect(private_messages).to be_an Array
+    end
+  end
+
   describe '#create_private_message' do
     before do
       stub_post("http://localhost:3000/posts?api_key=test_d7fd0429940&api_username=test_user")

--- a/spec/discourse_api/api/private_messages_spec.rb
+++ b/spec/discourse_api/api/private_messages_spec.rb
@@ -41,13 +41,13 @@ describe DiscourseApi::API::PrivateMessages do
       subject.create_private_message(
         title: "Confidential: Hello World!",
         raw: "This is the raw markdown for my private message",
-        target_usernames: ["user1", "user2"]
+        target_usernames: "user1,user2"
       )
     end
 
     it "makes a create private message request" do
       expect(a_post("http://localhost:3000/posts?api_key=test_d7fd0429940&api_username=test_user").with(body:
-          'archetype=private_message&raw=This+is+the+raw+markdown+for+my+private+message&target_usernames%5B%5D=user1&target_usernames%5B%5D=user2&title=Confidential%3A+Hello+World%21')
+          'archetype=private_message&raw=This+is+the+raw+markdown+for+my+private+message&target_usernames=user1%2Cuser2&title=Confidential%3A+Hello+World%21')
         ).to have_been_made
     end
   end


### PR DESCRIPTION
This PR adds the ability to fetch the private messages sent by the user. 
API Reference: [Sent Private Messages](http://docs.discourse.org/#tag/Private-Messages%2Fpaths%2F~1topics~1private-messages-sent~1%7Busername%7D.json%2Fget)