### PR TITLE
Add Title To SSO Synchronization

### DIFF
--- a/lib/discourse_api/api/sso.rb
+++ b/lib/discourse_api/api/sso.rb
@@ -10,6 +10,7 @@ module DiscourseApi
         sso.external_id = params[:external_id]
         sso.suppress_welcome_message = params[:suppress_welcome_message] === true
         sso.avatar_url = params[:avatar_url]
+        sso.title = params[:title]
         sso.avatar_force_update = params[:avatar_force_update] === true
         params.keys.select{|key| key.to_s.start_with?("custom") }.each do |custom_key|
           sso.custom_fields[custom_key] = params[custom_key]

--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -5,7 +5,7 @@ require 'openssl'
 module DiscourseApi
   class SingleSignOn
     ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update,
-                 :about_me, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message]
+                 :about_me, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message, :title]
     FIXNUMS = []
     BOOLS = [:avatar_force_update, :admin, :moderator, :suppress_welcome_message]
     #NONCE_EXPIRY_TIME = 10.minutes # minutes is a rails method and is causing an error. Is this needed in the api?


### PR DESCRIPTION
Title synchronization was added to the SSO functionality in
https://github.com/discourse/discourse/pull/4681

This allows us to gameify title acquisition, and programatically update
user titles.

Let me know if I need to change, add or delete anything, or if this isn't right for now.

Thanks!