### PR TITLE
Create and update groups

### DIFF
--- a/lib/discourse_api/api/groups.rb
+++ b/lib/discourse_api/api/groups.rb
@@ -4,9 +4,29 @@ module DiscourseApi
       def create_group(args)
         args = API.params(args)
                   .required(:name)
-                  .default(visible: true)
+                  .default(visibility_level: 0)
+                  .optional(:mentionable_level,
+                            :messageable_level,
+                            :automatic_membership_email_domains,
+                            :automatic_membership_retroactive,
+                            :title,
+                            :primary_group,
+                            :grant_trust_level,
+                            :incoming_email,
+                            :flair_url,
+                            :flair_bg_color,
+                            :flair_color,
+                            :bio_raw,
+                            :public_admission,
+                            :public_exit,
+                            :allow_membership_requests,
+                            :full_name,
+                            :default_notification_level,
+                            :usernames,
+                            :owner_usernames,
+                            :membership_request_template)
                   .to_h
-        post("/admin/groups", args)
+        post("/admin/groups", group: args)
       end
 
       def groups

--- a/lib/discourse_api/api/groups.rb
+++ b/lib/discourse_api/api/groups.rb
@@ -29,6 +29,34 @@ module DiscourseApi
         post("/admin/groups", group: args)
       end
 
+      def update_group(group_id, args)
+        args = API.params(args)
+                  .default(visibility_level: 0)
+                  .optional(:mentionable_level,
+                            :messageable_level,
+                            :name,
+                            :automatic_membership_email_domains,
+                            :automatic_membership_retroactive,
+                            :title,
+                            :primary_group,
+                            :grant_trust_level,
+                            :incoming_email,
+                            :flair_url,
+                            :flair_bg_color,
+                            :flair_color,
+                            :bio_raw,
+                            :public_admission,
+                            :public_exit,
+                            :allow_membership_requests,
+                            :full_name,
+                            :default_notification_level,
+                            :usernames,
+                            :owner_usernames,
+                            :membership_request_template)
+                  .to_h
+        put("/admin/groups/#{group_id}", group: args)
+      end
+
       def groups
         response = get("/admin/groups.json")
         response.body

--- a/spec/discourse_api/api/groups_spec.rb
+++ b/spec/discourse_api/api/groups_spec.rb
@@ -22,8 +22,12 @@ describe DiscourseApi::API::Groups do
     it "create new groups" do
       stub_post("http://localhost:3000/admin/groups?api_key=test_d7fd0429940&api_username=test_user")
       subject.create_group(name: "test_group")
+      params = {"group[name]" => "test_group", "group[visibility_level]" => 0}
+      escaped_params = params.map do |key, value|
+        [CGI.escape(key), value].join('=')
+      end.join('&')
       expect(a_post("http://localhost:3000/admin/groups?api_key=test_d7fd0429940&api_username=test_user").
-              with(body: {name: "test_group", visible: "true"})
+              with(body: escaped_params)
             ).to have_been_made
     end
 

--- a/spec/discourse_api/api/groups_spec.rb
+++ b/spec/discourse_api/api/groups_spec.rb
@@ -22,12 +22,18 @@ describe DiscourseApi::API::Groups do
     it "create new groups" do
       stub_post("http://localhost:3000/admin/groups?api_key=test_d7fd0429940&api_username=test_user")
       subject.create_group(name: "test_group")
-      params = {"group[name]" => "test_group", "group[visibility_level]" => 0}
-      escaped_params = params.map do |key, value|
-        [CGI.escape(key), value].join('=')
-      end.join('&')
+      params = escape_params("group[name]" => "test_group", "group[visibility_level]" => 0)
       expect(a_post("http://localhost:3000/admin/groups?api_key=test_d7fd0429940&api_username=test_user").
-              with(body: escaped_params)
+              with(body: params)
+            ).to have_been_made
+    end
+
+    it "update an existing group" do
+      stub_put("http://localhost:3000/admin/groups/42?api_key=test_d7fd0429940&api_username=test_user")
+      subject.update_group(42, name: "test_group")
+      params = escape_params("group[name]" => "test_group", "group[visibility_level]" => 0)
+      expect(a_put("http://localhost:3000/admin/groups/42?api_key=test_d7fd0429940&api_username=test_user").
+              with(body: params)
             ).to have_been_made
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,3 +59,9 @@ end
 def fixture(file)
   File.new(fixture_path + '/' + file)
 end
+
+def escape_params(params)
+  params.map do |key, value|
+    [CGI.escape(key), value].join('=')
+  end.join('&')
+end


### PR DESCRIPTION
This PR does two things:

1) Fixes the `create_group` API call to send up params like `group[name]` as (newly?) required by Discourse. Previously, they were getting sent up as `name`, and `create_group` was failing. I also added the rest of the optional params as defined in the Admin::GroupsController here: https://github.com/discourse/discourse/blob/master/app/controllers/admin/groups_controller.rb#L193

2) Creates an `update_group` API call that updates groups.