### PR TITLE
Adding the `group` method, which finds a group by name

### DIFF
--- a/lib/discourse_api/api/groups.rb
+++ b/lib/discourse_api/api/groups.rb
@@ -62,6 +62,11 @@ module DiscourseApi
         response.body
       end
 
+      def group(group_name)
+        response = get("/groups/#{group_name}.json")
+        response.body
+      end
+
       def group_add(group_id, users)
         users.keys.each do |key|
           # Accept arrays and convert to comma-delimited string.

--- a/spec/discourse_api/api/groups_spec.rb
+++ b/spec/discourse_api/api/groups_spec.rb
@@ -19,6 +19,12 @@ describe DiscourseApi::API::Groups do
       groups.each { |g| expect(g).to be_a Hash }
     end
 
+    it "returns a single group" do
+      stub_get("http://localhost:3000/groups/some-group.json?api_key=test_d7fd0429940&api_username=test_user").to_return(body: fixture("group.json"), headers: { content_type: "application/json" })
+      group = subject.group('some-group')
+      expect(group['basic_group']).to be_a Hash
+    end
+
     it "create new groups" do
       stub_post("http://localhost:3000/admin/groups?api_key=test_d7fd0429940&api_username=test_user")
       subject.create_group(name: "test_group")

--- a/spec/fixtures/group.json
+++ b/spec/fixtures/group.json
@@ -1,0 +1,9 @@
+{"basic_group": {
+        "id": 101,
+        "name": "group_1",
+        "user_count": 17,
+        "automatic": false,
+        "alias_level": 0,
+        "visible": true
+    }
+}


### PR DESCRIPTION
Add a `#group` method that takes a `group_name` as an argument and hits `/groups/<group_name>.json`.