### PR TITLE
Adds base error class

### DIFF
--- a/lib/discourse_api/error.rb
+++ b/lib/discourse_api/error.rb
@@ -1,5 +1,8 @@
 module DiscourseApi
-  class Error < StandardError
+  class DiscourseError < StandardError
+  end
+
+  class Error < DiscourseError
     attr_reader :wrapped_exception
 
     # Initializes a new Error object
@@ -12,15 +15,15 @@ module DiscourseApi
     end
   end
 
-  class UnauthenticatedError < StandardError
+  class UnauthenticatedError < DiscourseError
   end
 
-  class NotFoundError < StandardError
+  class NotFoundError < DiscourseError
   end
 
-  class UnprocessableEntity < StandardError
+  class UnprocessableEntity < DiscourseError
   end
 
-  class TooManyRequests < StandardError
+  class TooManyRequests < DiscourseError
   end
 end


### PR DESCRIPTION
Catch all API errors with a single `rescue DiscourseApi::DiscourseError => error`.

A la https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/errors.rb#L39