### PR TITLE
Add support for relative paths

### DIFF
--- a/spec/discourse_api/client_spec.rb
+++ b/spec/discourse_api/client_spec.rb
@@ -65,39 +65,78 @@ describe DiscourseApi::Client do
   describe "#delete" do
     before do
       stub_delete("http://localhost:3000/test/delete?api_key=test_d7fd0429940&api_username=test_user").with(query: { deleted: "object" })
+      subject.api_key = 'test_d7fd0429940'
+      subject.api_username = 'test_user'
     end
 
     it "allows custom delete requests" do
-      subject.api_key = 'test_d7fd0429940'
-      subject.api_username = 'test_user'
       subject.delete("/test/delete", { deleted: "object" })
       expect(a_delete("http://localhost:3000/test/delete?api_key=test_d7fd0429940&api_username=test_user").with(query: { deleted: "object" })).to have_been_made
+    end
+
+    context 'when using a host with a subdirectory' do
+      subject { DiscourseApi::Client.new('http://localhost:3000/forum') }
+
+      before do
+        stub_delete("http://localhost:3000/forum/test/delete?api_key=test_d7fd0429940&api_username=test_user").with(query: { deleted: "object" })
+      end
+
+      it "allows custom delete requests" do
+        subject.delete("/test/delete", { deleted: "object" })
+        expect(a_delete("http://localhost:3000/forum/test/delete?api_key=test_d7fd0429940&api_username=test_user").with(query: { deleted: "object" })).to have_been_made
+      end
     end
   end
 
   describe "#post" do
     before do
       stub_post("http://localhost:3000/test/post?api_key=test_d7fd0429940&api_username=test_user").with(body: { created: "object"})
+      subject.api_key = 'test_d7fd0429940'
+      subject.api_username = 'test_user'
     end
 
     it "allows custom post requests" do
-      subject.api_key = 'test_d7fd0429940'
-      subject.api_username = 'test_user'
       subject.post("/test/post", { created: "object" })
       expect(a_post("http://localhost:3000/test/post?api_key=test_d7fd0429940&api_username=test_user").with(body: { created: "object"})).to have_been_made
+    end
+
+    context 'when using a host with a subdirectory' do
+      subject { DiscourseApi::Client.new('http://localhost:3000/forum') }
+
+      before do
+        stub_post("http://localhost:3000/forum/test/post?api_key=test_d7fd0429940&api_username=test_user").with(body: { created: "object"})
+      end
+
+      it "allows custom post requests" do
+        subject.post("/test/post", { created: "object" })
+        expect(a_post("http://localhost:3000/forum/test/post?api_key=test_d7fd0429940&api_username=test_user").with(body: { created: "object"})).to have_been_made
+      end
     end
   end
 
   describe "#put" do
     before do
       stub_put("http://localhost:3000/test/put?api_key=test_d7fd0429940&api_username=test_user").with(body: { updated: "object" })
+      subject.api_key = 'test_d7fd0429940'
+      subject.api_username = 'test_user'
     end
 
     it "allows custom put requests" do
-      subject.api_key = 'test_d7fd0429940'
-      subject.api_username = 'test_user'
       subject.put("/test/put", { updated: "object" })
       expect(a_put("http://localhost:3000/test/put?api_key=test_d7fd0429940&api_username=test_user").with(body: { updated: "object" })).to have_been_made
+    end
+
+    context 'when using a host with a subdirectory' do
+      subject { DiscourseApi::Client.new('http://localhost:3000/forum') }
+
+      before do
+        stub_put("http://localhost:3000/forum/test/put?api_key=test_d7fd0429940&api_username=test_user").with(body: { updated: "object" })
+      end
+
+      it "allows custom post requests" do
+        subject.put("/test/put", { updated: "object" })
+        expect(a_put("http://localhost:3000/forum/test/put?api_key=test_d7fd0429940&api_username=test_user").with(body: { updated: "object" })).to have_been_made
+      end
     end
   end
 


### PR DESCRIPTION
Faraday client strips out any subdirectory path in the host if there is
a leading slash in the request. This change checks if the Discourse host
has a subdirectory, and strips out the leading slash on every
GET/POST/PUT/DELETE request to allow for subdirectories.

E.g.
**Old Behaviour**
When running `client.latest_topics`
Host: `http://www.myblog.com/discourse`
Expected: `http://www.myblog.com/discourse/latest.json`
Actual: `http://www.myblog.com/latest.json`

**New Behaviour**
When running `client.latest_topics`
Host: `http://www.myblog.com/discourse`
Expected: `http://www.myblog.com/discourse/latest.json`
Actual: `http://www.myblog.com/discourse/latest.json`