### PR TITLE
Adds faraday response env to errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ client.create_private_message(                  #=> Creates a private messages b
 
 ```
 
+You can handle some basic errors by rescuing from certain error classes and inspecting the response object passed to those errors:
+
+```ruby
+begin
+  client.create_group({ name: 'NO' })
+rescue DiscourseApi::UnprocessableEntity => error
+  # `body` is something like `{ errors: ["Name must be at least 3 characters"] }`
+  # This outputs "Name must be at least 3 characters"
+  puts error.response.body['errors'].first
+end
+```
+
+Check out [lib/discourse_api/error.rb](lib/discourse_api/error.rb) and [lib/discourse_api/client.rb](lib/discourse_api/client.rb)'s `handle_error` method for the types of errors raised by the API.
 
 ## Contributing
 

--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -138,13 +138,13 @@ module DiscourseApi
     def handle_error(response)
       case response.status
       when 403
-        raise DiscourseApi::UnauthenticatedError.new(response.env[:body])
+        raise DiscourseApi::UnauthenticatedError.new(response.env[:body], response.env)
       when 404, 410
-        raise DiscourseApi::NotFoundError.new(response.env[:body])
+        raise DiscourseApi::NotFoundError.new(response.env[:body], response.env)
       when 422
-        raise DiscourseApi::UnprocessableEntity.new(response.env[:body])
+        raise DiscourseApi::UnprocessableEntity.new(response.env[:body], response.env)
       when 429
-        raise DiscourseApi::TooManyRequests.new(response.env[:body])
+        raise DiscourseApi::TooManyRequests.new(response.env[:body], response.env)
       when 500...600
         raise DiscourseApi::Error.new(response.env[:body])
       end

--- a/lib/discourse_api/error.rb
+++ b/lib/discourse_api/error.rb
@@ -1,5 +1,11 @@
 module DiscourseApi
   class DiscourseError < StandardError
+    attr_reader :response
+
+    def initialize(message, response = nil)
+      super(message)
+      @response = response
+    end
   end
 
   class Error < DiscourseError


### PR DESCRIPTION
I added the faraday `env` response to `handle_error` error initialization. I was finding that passing response.env[:body] to the "message" slot of the discourse errors automatically called "to_s" on the response. So if you wanted to use `{ errors: [' Name has already been taken'] }` as a hash, you'd have to additionally parse that string (`"{\"errors\"=>[\"Name has already been taken\"]}"`).

With this change, this is possible:

```ruby
begin
  @client.create_group(args)
rescue DiscourseApi::UnprocessableEntity => error
  # Name has already been taken
  puts error.response.body['errors'].first
end
```

where previously `error.message` would've been `"{\"errors\"=>[\"Name has already been taken\"]}"` which you would've had to parse with `eval` or something similar (see: https://stackoverflow.com/questions/1667630/how-do-i-convert-a-string-object-into-a-hash-object)

Left in the original first param for backwards compatibility. 

If there's a different way to accomplish this, I'd love to hear of it. All tests pass but this could probably use some additional eyeballs.