### PR TITLE
FEATURE: Add add_groups and remove_groups to sync_sso

### DIFF
--- a/lib/discourse_api/api/sso.rb
+++ b/lib/discourse_api/api/sso.rb
@@ -12,6 +12,8 @@ module DiscourseApi
         sso.avatar_url = params[:avatar_url]
         sso.title = params[:title]
         sso.avatar_force_update = params[:avatar_force_update] === true
+        sso.add_groups = params[:add_groups]
+        sso.remove_groups = params[:remove_groups]
         params.keys.select{|key| key.to_s.start_with?("custom") }.each do |custom_key|
           sso.custom_fields[custom_key] = params[custom_key]
         end


### PR DESCRIPTION
This PR allows the `add_groups` and `remove_groups` properties to be set by `sync_sso`. If required, I can add a test to this early next week.

Related topic on meta: https://meta.discourse.org/t/sync-sso-returns-user-info-but-doesnt-update/103583.