### PR TITLE
Adding params to users#list_users

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -61,8 +61,8 @@ module DiscourseApi
         post("/admin/users/invite_admin", args)
       end
 
-      def list_users(type)
-        response = get("admin/users/list/#{type}.json")
+      def list_users(type, params = {})
+        response = get("admin/users/list/#{type}.json", params)
         response[:body]
       end
 


### PR DESCRIPTION
To allow search and pagination the list_users method need to support receiving extra params that will be passed to the API endpoint (which already supports a series of params).