### PR TITLE
Adds the change topic owner endpoint

### DIFF
--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -11,7 +11,7 @@ module DiscourseApi
                   .optional(:skip_validations, :category, :auto_track, :created_at, :api_username)
         post("/posts", args.to_h)
       end
-
+      
       def create_topic_action(args)
         args = API.params(args)
                    .required(:id, :post_action_type_id)
@@ -72,6 +72,11 @@ module DiscourseApi
         end
         response = get(url)
         response[:body]
+      end
+      
+      def change_owner(topic_id, target_username, post_id)
+        post("/t/#{topic_id}/change-owner.json",
+          {topic_id: topic_id, username: target_username, post_ids: [post_id]})
       end
     end
   end


### PR DESCRIPTION
Technically simple: just adding a new method to the topics module. Yet I wonder about the appropriateness: given the endpoint isn't documented in the Discourse API Docs (https://docs.discourse.org/#tag/Topics), this may not be an endpoint Discourse wants to commit to.
This was reverse engineered from:
- https://github.com/discourse/discourse/blob/70fdc1036598df09d236e013fea7fcf750c7363f/app/controllers/topics_controller.rb
- https://github.com/discourse/discourse/blob/c30996129f31e9ac702c830bb9501d2f0ed25b5b/spec/requests/topics_controller_spec.rb