### PR TITLE
Add 201 Created and 204 No Content as valid POST responses

### DIFF
--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -86,7 +86,7 @@ module DiscourseApi
     def post(path, params={})
       response = request(:post, path, params)
       case response.status
-      when 200
+      when 200, 201, 204
         response.body
       else
         raise DiscourseApi::Error, response.body


### PR DESCRIPTION
Some undocumented API endpoints that use POST actually return as 201 but the gem interprets as an error. For example: `POST admin/themes/import`.

By the same token, 204 can be a valid POST response as per [this](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5), so this should not be considered an error either.