### PR TITLE
user-badges endpoint

### DIFF
--- a/lib/discourse_api/api/badges.rb
+++ b/lib/discourse_api/api/badges.rb
@@ -8,7 +8,7 @@ module DiscourseApi
       end
 
       def user_badges(username)
-        response = get("/users/#{username}/activity/badges.json")
+        response = get("/user-badges/#{username}.json")
         response.body['badges']
       end
 

--- a/spec/discourse_api/api/badges_spec.rb
+++ b/spec/discourse_api/api/badges_spec.rb
@@ -20,14 +20,14 @@ describe DiscourseApi::API::Badges do
     end
   end
 
-  describe "#user_badges" do
+  describe "#user-badges" do
     before do
-      stub_get("http://localhost:3000/users/test_user/activity/badges.json").to_return(body: fixture("user_badges.json"), headers: { content_type: "application/json" })
+      stub_get("http://localhost:3000/user-badges/test_user.json").to_return(body: fixture("user_badges.json"), headers: { content_type: "application/json" })
     end
 
     it "requests the correct resource" do
       subject.user_badges('test_user')
-      expect(a_get("http://localhost:3000/users/test_user/activity/badges.json")).to have_been_made
+      expect(a_get("http://localhost:3000/user-badges/test_user.json")).to have_been_made
     end
 
     it "returns the requested user badges" do


### PR DESCRIPTION
- user-badges endpoint for full badges list
-   vs. /u/user_name/activity/badges, which gave partial list
- tests