### PR TITLE
Expanded list of allowed messages

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -31,7 +31,8 @@ module DiscourseApi
 
       def update_user(username, args)
         args = API.params(args)
-          .optional(:name, :title, :bio_raw, :location, :website, :profile_background, :card_background)
+          .optional(:name, :title, :bio_raw, :location, :website, :profile_background, :card_background,
+                    :email_messages_level, :mailing_list_mode, :homepage_id, :theme_ids, :user_fields)
           .to_h
         put("/u/#{username}", args)
       end


### PR DESCRIPTION
- Not the complete list, but best we can do for now given the use of .optional to control the possible values and contributors submitting expansions to that list based on their own needs.

- Unfortunately update_user fails silently when a non-allowed value is tried in the api.