### PR TITLE
added optional param :all to #group_members so we can return all members

### DIFF
--- a/lib/discourse_api/api/groups.rb
+++ b/lib/discourse_api/api/groups.rb
@@ -107,11 +107,14 @@ module DiscourseApi
       end
 
       def group_members(group_name, params = {})
+        options = params
         params = API.params(params)
           .optional(:offset, :limit)
           .default(offset: 0, limit: 100)
           .to_h
         response = get("/groups/#{group_name}/members.json", params)
+
+        response.body if options[:all] == true
         response.body['members']
       end
 

--- a/lib/discourse_api/api/groups.rb
+++ b/lib/discourse_api/api/groups.rb
@@ -114,8 +114,11 @@ module DiscourseApi
           .to_h
         response = get("/groups/#{group_name}/members.json", params)
 
-        response.body if options[:all] == true
-        response.body['members']
+        if options[:all] == true
+          response.body
+        else
+          response.body['members']
+        end
       end
 
       def group_set_user_notification_level(group, user_id, notification_level)

--- a/spec/discourse_api/api/groups_spec.rb
+++ b/spec/discourse_api/api/groups_spec.rb
@@ -91,18 +91,26 @@ describe DiscourseApi::API::Groups do
     end
 
     describe "group members" do
-      before do
+      it "list members" do
         stub_get("#{host}/groups/mygroup/members.json?limit=100&offset=0").to_return(body: fixture("members_0.json"), headers: { content_type: "application/json" })
         stub_get("#{host}/groups/mygroup/members.json?limit=100&offset=100").to_return(body: fixture("members_1.json"), headers: { content_type: "application/json" })
-      end
-
-      it "list members" do
         members = subject.group_members('mygroup')
         expect(a_get("#{host}/groups/mygroup/members.json?limit=100&offset=0")).to have_been_made
         expect(members.length).to eq(100)
         members = subject.group_members('mygroup', offset: 100)
         expect(a_get("#{host}/groups/mygroup/members.json?limit=100&offset=100")).to have_been_made
         expect(members.length).to eq(90)
+      end
+
+      context "with :all params" do
+        it "lists members and owners" do
+          stub_get("#{host}/groups/mygroup/members.json?limit=100&offset=0").to_return(body: fixture("members_2.json"), headers: { content_type: "application/json" })
+          member_data = subject.group_members('mygroup', all: true)
+          expect(a_get("#{host}/groups/mygroup/members.json?limit=100&offset=0")).to have_been_made
+          expect(member_data["members"].length).to eq(100)
+          expect(member_data["owners"].length).to eq(7)
+          expect(member_data.keys.sort).to eq(["members", "meta", "owners"])
+        end
       end
     end
 

--- a/spec/fixtures/members_2.json
+++ b/spec/fixtures/members_2.json
@@ -1,0 +1,437 @@
+{
+    "members": [{
+        "id": 1,
+        "name": "Test 0",
+        "username": "Test_0"
+    }, {
+        "id": 2,
+        "name": "Test 1",
+        "username": "Test_1"
+    }, {
+        "id": 3,
+        "name": "Test 2",
+        "username": "Test_2"
+    }, {
+        "id": 4,
+        "name": "Test 3",
+        "username": "Test_3"
+    }, {
+        "id": 5,
+        "name": "Test 4",
+        "username": "Test_4"
+    }, {
+        "id": 6,
+        "name": "Test 5",
+        "username": "Test_5"
+    }, {
+        "id": 7,
+        "name": "Test 6",
+        "username": "Test_6"
+    }, {
+        "id": 8,
+        "name": "Test 7",
+        "username": "Test_7"
+    }, {
+        "id": 9,
+        "name": "Test 8",
+        "username": "Test_8"
+    }, {
+        "id": 10,
+        "name": "Test 9",
+        "username": "Test_9"
+    }, {
+        "id": 11,
+        "name": "Test 10",
+        "username": "Test_10"
+    }, {
+        "id": 12,
+        "name": "Test 11",
+        "username": "Test_11"
+    }, {
+        "id": 13,
+        "name": "Test 12",
+        "username": "Test_12"
+    }, {
+        "id": 14,
+        "name": "Test 13",
+        "username": "Test_13"
+    }, {
+        "id": 15,
+        "name": "Test 14",
+        "username": "Test_14"
+    }, {
+        "id": 16,
+        "name": "Test 15",
+        "username": "Test_15"
+    }, {
+        "id": 17,
+        "name": "Test 16",
+        "username": "Test_16"
+    }, {
+        "id": 18,
+        "name": "Test 17",
+        "username": "Test_17"
+    }, {
+        "id": 19,
+        "name": "Test 18",
+        "username": "Test_18"
+    }, {
+        "id": 20,
+        "name": "Test 19",
+        "username": "Test_19"
+    }, {
+        "id": 21,
+        "name": "Test 20",
+        "username": "Test_20"
+    }, {
+        "id": 22,
+        "name": "Test 21",
+        "username": "Test_21"
+    }, {
+        "id": 23,
+        "name": "Test 22",
+        "username": "Test_22"
+    }, {
+        "id": 24,
+        "name": "Test 23",
+        "username": "Test_23"
+    }, {
+        "id": 25,
+        "name": "Test 24",
+        "username": "Test_24"
+    }, {
+        "id": 26,
+        "name": "Test 25",
+        "username": "Test_25"
+    }, {
+        "id": 27,
+        "name": "Test 26",
+        "username": "Test_26"
+    }, {
+        "id": 28,
+        "name": "Test 27",
+        "username": "Test_27"
+    }, {
+        "id": 29,
+        "name": "Test 28",
+        "username": "Test_28"
+    }, {
+        "id": 30,
+        "name": "Test 29",
+        "username": "Test_29"
+    }, {
+        "id": 31,
+        "name": "Test 30",
+        "username": "Test_30"
+    }, {
+        "id": 32,
+        "name": "Test 31",
+        "username": "Test_31"
+    }, {
+        "id": 33,
+        "name": "Test 32",
+        "username": "Test_32"
+    }, {
+        "id": 34,
+        "name": "Test 33",
+        "username": "Test_33"
+    }, {
+        "id": 35,
+        "name": "Test 34",
+        "username": "Test_34"
+    }, {
+        "id": 36,
+        "name": "Test 35",
+        "username": "Test_35"
+    }, {
+        "id": 37,
+        "name": "Test 36",
+        "username": "Test_36"
+    }, {
+        "id": 38,
+        "name": "Test 37",
+        "username": "Test_37"
+    }, {
+        "id": 39,
+        "name": "Test 38",
+        "username": "Test_38"
+    }, {
+        "id": 40,
+        "name": "Test 39",
+        "username": "Test_39"
+    }, {
+        "id": 41,
+        "name": "Test 40",
+        "username": "Test_40"
+    }, {
+        "id": 42,
+        "name": "Test 41",
+        "username": "Test_41"
+    }, {
+        "id": 43,
+        "name": "Test 42",
+        "username": "Test_42"
+    }, {
+        "id": 44,
+        "name": "Test 43",
+        "username": "Test_43"
+    }, {
+        "id": 45,
+        "name": "Test 44",
+        "username": "Test_44"
+    }, {
+        "id": 46,
+        "name": "Test 45",
+        "username": "Test_45"
+    }, {
+        "id": 47,
+        "name": "Test 46",
+        "username": "Test_46"
+    }, {
+        "id": 48,
+        "name": "Test 47",
+        "username": "Test_47"
+    }, {
+        "id": 49,
+        "name": "Test 48",
+        "username": "Test_48"
+    }, {
+        "id": 50,
+        "name": "Test 49",
+        "username": "Test_49"
+    }, {
+        "id": 51,
+        "name": "Test 50",
+        "username": "Test_50"
+    }, {
+        "id": 52,
+        "name": "Test 51",
+        "username": "Test_51"
+    }, {
+        "id": 53,
+        "name": "Test 52",
+        "username": "Test_52"
+    }, {
+        "id": 54,
+        "name": "Test 53",
+        "username": "Test_53"
+    }, {
+        "id": 55,
+        "name": "Test 54",
+        "username": "Test_54"
+    }, {
+        "id": 56,
+        "name": "Test 55",
+        "username": "Test_55"
+    }, {
+        "id": 57,
+        "name": "Test 56",
+        "username": "Test_56"
+    }, {
+        "id": 58,
+        "name": "Test 57",
+        "username": "Test_57"
+    }, {
+        "id": 59,
+        "name": "Test 58",
+        "username": "Test_58"
+    }, {
+        "id": 60,
+        "name": "Test 59",
+        "username": "Test_59"
+    }, {
+        "id": 61,
+        "name": "Test 60",
+        "username": "Test_60"
+    }, {
+        "id": 62,
+        "name": "Test 61",
+        "username": "Test_61"
+    }, {
+        "id": 63,
+        "name": "Test 62",
+        "username": "Test_62"
+    }, {
+        "id": 64,
+        "name": "Test 63",
+        "username": "Test_63"
+    }, {
+        "id": 65,
+        "name": "Test 64",
+        "username": "Test_64"
+    }, {
+        "id": 66,
+        "name": "Test 65",
+        "username": "Test_65"
+    }, {
+        "id": 67,
+        "name": "Test 66",
+        "username": "Test_66"
+    }, {
+        "id": 68,
+        "name": "Test 67",
+        "username": "Test_67"
+    }, {
+        "id": 69,
+        "name": "Test 68",
+        "username": "Test_68"
+    }, {
+        "id": 70,
+        "name": "Test 69",
+        "username": "Test_69"
+    }, {
+        "id": 71,
+        "name": "Test 70",
+        "username": "Test_70"
+    }, {
+        "id": 72,
+        "name": "Test 71",
+        "username": "Test_71"
+    }, {
+        "id": 73,
+        "name": "Test 72",
+        "username": "Test_72"
+    }, {
+        "id": 74,
+        "name": "Test 73",
+        "username": "Test_73"
+    }, {
+        "id": 75,
+        "name": "Test 74",
+        "username": "Test_74"
+    }, {
+        "id": 76,
+        "name": "Test 75",
+        "username": "Test_75"
+    }, {
+        "id": 77,
+        "name": "Test 76",
+        "username": "Test_76"
+    }, {
+        "id": 78,
+        "name": "Test 77",
+        "username": "Test_77"
+    }, {
+        "id": 79,
+        "name": "Test 78",
+        "username": "Test_78"
+    }, {
+        "id": 80,
+        "name": "Test 79",
+        "username": "Test_79"
+    }, {
+        "id": 81,
+        "name": "Test 80",
+        "username": "Test_80"
+    }, {
+        "id": 82,
+        "name": "Test 81",
+        "username": "Test_81"
+    }, {
+        "id": 83,
+        "name": "Test 82",
+        "username": "Test_82"
+    }, {
+        "id": 84,
+        "name": "Test 83",
+        "username": "Test_83"
+    }, {
+        "id": 85,
+        "name": "Test 84",
+        "username": "Test_84"
+    }, {
+        "id": 86,
+        "name": "Test 85",
+        "username": "Test_85"
+    }, {
+        "id": 87,
+        "name": "Test 86",
+        "username": "Test_86"
+    }, {
+        "id": 88,
+        "name": "Test 87",
+        "username": "Test_87"
+    }, {
+        "id": 89,
+        "name": "Test 88",
+        "username": "Test_88"
+    }, {
+        "id": 90,
+        "name": "Test 89",
+        "username": "Test_89"
+    }, {
+        "id": 91,
+        "name": "Test 90",
+        "username": "Test_90"
+    }, {
+        "id": 92,
+        "name": "Test 91",
+        "username": "Test_91"
+    }, {
+        "id": 93,
+        "name": "Test 92",
+        "username": "Test_92"
+    }, {
+        "id": 94,
+        "name": "Test 93",
+        "username": "Test_93"
+    }, {
+        "id": 95,
+        "name": "Test 94",
+        "username": "Test_94"
+    }, {
+        "id": 96,
+        "name": "Test 95",
+        "username": "Test_95"
+    }, {
+        "id": 97,
+        "name": "Test 96",
+        "username": "Test_96"
+    }, {
+        "id": 98,
+        "name": "Test 97",
+        "username": "Test_97"
+    }, {
+        "id": 99,
+        "name": "Test 98",
+        "username": "Test_98"
+    }, {
+        "id": 100,
+        "name": "Test 99",
+        "username": "Test_99"
+    }],
+    "owners": [{
+        "id": 101,
+        "name": "Onwer 0",
+        "username": "Owner_0"
+    }, {
+        "id": 102,
+        "name": "Onwer 1",
+        "username": "Owner_1"
+    }, {
+        "id": 103,
+        "name": "Onwer 2",
+        "username": "Owner_2"
+    }, {
+        "id": 104,
+        "name": "Onwer 3",
+        "username": "Owner_3"
+    }, {
+        "id": 105,
+        "name": "Onwer 4",
+        "username": "Owner_4"
+    }, {
+        "id": 106,
+        "name": "Onwer 5",
+        "username": "Owner_5"
+    }, {
+        "id": 107,
+        "name": "Onwer 6",
+        "username": "Owner_6"
+    }],
+    "meta": {
+        "total": 107,
+        "limit": 0,
+        "offset": 0
+    }
+}


### PR DESCRIPTION
including owners.

Currently the actual Discourse API returns a hash with the keys "members, owners, and meta"

The current implementation in this discourse_api gem returns only "members". I added an optional argument `all` that can be passed to `#group_members` so we can get `members`,  and `owners`