### PR TITLE
Updates and fixes for topic and category methods.

### DIFF
--- a/lib/discourse_api/api/categories.rb
+++ b/lib/discourse_api/api/categories.rb
@@ -8,7 +8,8 @@ module DiscourseApi
       def create_category(args = {})
         args = API.params(args)
           .required(:name, :color, :text_color)
-          .optional(:description, :permissions, :custom_fields)
+          .optional(:slug, :permissions, :auto_close_hours, :auto_close_based_on_last_post, :position, :email_in,
+                             :email_in_allow_strangers, :logo_url, :background_url, :allow_badges, :topic_template, :custom_fields, :description)
           .default(parent_category_id: nil)
         response = post("/categories", args)
         response['category']
@@ -19,7 +20,7 @@ module DiscourseApi
         args = API.params(args)
           .required(:id, :name, :color, :text_color)
           .optional(:slug, :permissions, :auto_close_hours, :auto_close_based_on_last_post, :position, :email_in,
-                             :email_in_allow_strangers, :logo_url, :background_url, :allow_badges, :topic_template, :custom_fields)
+                             :email_in_allow_strangers, :logo_url, :background_url, :allow_badges, :topic_template, :custom_fields, :description)
           .default(parent_category_id: nil)
         response = put("/categories/#{category_id}", args)
         response['body']['category'] if response['body']

--- a/lib/discourse_api/api/params.rb
+++ b/lib/discourse_api/api/params.rb
@@ -16,6 +16,9 @@ module DiscourseApi
 
       def required(*keys)
         @required.concat(keys)
+        @required.each do |k|
+          raise ArgumentError.new("#{k} is required but not specified") unless @args.key?(k)
+        end
         self
       end
 
@@ -36,7 +39,6 @@ module DiscourseApi
 
         @required.each do |k|
           h[k] = @args[k]
-          raise ArgumentError.new("#{k} is required but not specified") unless h[k]
         end
 
         @optional.each do |k|

--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -46,7 +46,7 @@ module DiscourseApi
         params = API.params(params)
           .required(:status, :enabled)
           .optional(:api_username)
-        put("/t/#{topic_slug}/#{topic_id}/status", params.to_h)
+        put("/t/#{topic_id}/status", params.to_h)
       end
 
       def topic(id, params = {})

--- a/spec/discourse_api/api/params_spec.rb
+++ b/spec/discourse_api/api/params_spec.rb
@@ -9,6 +9,10 @@ describe DiscourseApi::API::Params do
     expect { params_for({o1: "test"}).to_h }.to raise_error(ArgumentError)
   end
 
+  it "should not raise when a required param is false" do
+    expect { params_for({r1: false}).to_h }.not_to raise_error
+  end
+
   it "should not include optional params when not provided" do
     expect(params_for({r1: "test"}).to_h).not_to include(:o1)
   end

--- a/spec/discourse_api/api/topics_spec.rb
+++ b/spec/discourse_api/api/topics_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper'
 describe DiscourseApi::API::Topics do
   subject { DiscourseApi::Client.new("#{host}", "test_d7fd0429940", "test_user") }
 
+  describe "#change_topic_status" do
+    before do
+      stub_put("#{host}/t/57/status").to_return(body: fixture("topic.json"), headers: { content_type: "application/json" })
+    end
+
+    it "changes the topic status" do
+      subject.change_topic_status(nil, 57, { status: 'visible', enabled: false })
+      expect(a_put("#{host}/t/57/status")).to have_been_made
+    end
+  end
+
   describe "#invite_user_to_topic" do
     before do
       stub_post("#{host}/t/12/invite").to_return(body: fixture("topic_invite_user.json"), headers: { content_type: "application/json" })


### PR DESCRIPTION
- Fix bug with required params that are `false`.
  * `ArgumentError` was raised in this case.
- Allow more optional parameters when creating a category.
  * I'm not sure why these params weren't already listed as optional. I tested specifying a `slug` and it gets set correctly, so it looks like these optional values will be used to create the category if they are specified.
- Don't require topic slug when updating topic status.
  * Update the request to match the route in the docs: https://docs.discourse.org/#tag/Topics/paths/~1t~1{id}~1status/put