### PR TITLE
Add attributes to sync_sso method

### DIFF
--- a/lib/discourse_api/api/sso.rb
+++ b/lib/discourse_api/api/sso.rb
@@ -11,6 +11,9 @@ module DiscourseApi
         sso.external_id = params[:external_id]
         sso.suppress_welcome_message = params[:suppress_welcome_message] === true
         sso.avatar_url = params[:avatar_url]
+        sso.profile_background_url = params[:profile_background_url]
+        sso.card_background_url = params[:card_background_url]
+        sso.bio = params[:bio]
         sso.title = params[:title]
         sso.avatar_force_update = params[:avatar_force_update] === true
         sso.add_groups = params[:add_groups]

--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -5,7 +5,7 @@ require 'openssl'
 
 module DiscourseApi
   class SingleSignOn
-    ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update, :require_activation,
+    ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :profile_background_url, :card_background_url, :avatar_force_update, :require_activation,
                  :bio, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message, :title,
                  :add_groups, :remove_groups, :groups, :locale, :locale_force_update]
     FIXNUMS = []


### PR DESCRIPTION
When syncing with SSO enabled, some attributes don't get updated - I added `bio`, `profile_background_url` and `card_background_url`.

I hope these are the only places where they need to be added? I only edited the files directly on github and haven't tested yet.