### PR TITLE
hot_topics method no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ client.ssl(...)                                 #=> specify SSL connection setti
 
 # Topic endpoints
 client.latest_topics                            #=> Gets a list of the latest topics
-client.hot_topics                               #=> Gets a list of hot topics
 client.new_topics                               #=> Gets a list of new topics
 client.topics_by("sam")                         #=> Gets a list of topics created by user "sam"
 client.topic(57)                                #=> Gets the topic with id 57


### PR DESCRIPTION
### Summary

The `hot_topics` method was removed in 1c1fcbf0a34c527a7a3e98b28fd1810cc5a6fcdb and seemingly added back to the `README.md` in fbbb11fe149ba8ae9fe367bb616f5b6d814b6b15. This removes it again as it no longer exists in the codebase.

Ideally a new [`top_topics`](https://docs.discourse.org/#tag/Topics/paths/~1top.json/get) method should be added as a replacement, c.f a3cb6adbed7c8769dcf62c5fe7dcb6d1d7488b15

