### PR TITLE
FIX: Update to use new tag endpoint

### DIFF
--- a/lib/discourse_api/api/tags.rb
+++ b/lib/discourse_api/api/tags.rb
@@ -3,7 +3,7 @@ module DiscourseApi
   module API
     module Tags
       def show_tag(tag)
-        response = get("/tags/#{tag}")
+        response = get("/tag/#{tag}")
         response[:body]
       end
     end


### PR DESCRIPTION
The legacy "tags" route was removed recently:

https://meta.discourse.org/t/-/169414/5?u=blake