### PR TITLE
Require Ruby >= 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Support for Ruby 2.3 and 2.4
 
 ## [0.43.1] - 2020-11-04
 ### Fixed

--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 2.0'
   spec.add_development_dependency 'rubocop-discourse'
 
-  spec.required_ruby_version = '>= 2.2.3'
+  spec.required_ruby_version = '>= 2.5.0'
 end


### PR DESCRIPTION
The support for Ruby 2.3 has ended in March 2019 (https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/) and Ruby 2.4 is no longer supported as of April 2020 (https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/)

We already don't test against those versions in our CI setup.

This fixes (I hope) the build-breaking rubocop error:
"RuboCop found unsupported Ruby version 2.2 in `required_ruby_version` parameter (in discourse_api.gemspec). 2.2-compatible analysis was dropped after version 0.68.
Supported versions: 2.4, 2.5, 2.6, 2.7, 3.0"