### PR TITLE
Support passing approved to #create_user

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -52,7 +52,7 @@ module DiscourseApi
       def create_user(args)
         args = API.params(args)
           .required(:name, :email, :password, :username)
-          .optional(:active, :staged, :user_fields)
+          .optional(:active, :approved, :staged, :user_fields)
           .to_h
         post("/users", args)
       end


### PR DESCRIPTION
[API supports](https://docs.discourse.org/#tag/Users/paths/~1users/post) sending the `approved` option to `POST /users`.