### PR TITLE
Add #generate_user_api_key for user-specific API key

### DIFF
--- a/examples/generate_user_api_key.rb
+++ b/examples/generate_user_api_key.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require File.expand_path('../../lib/discourse_api', __FILE__)
+
+config = DiscourseApi::ExampleHelper.load_yml
+
+client = DiscourseApi::Client.new(config['host'] || 'http://localhost:3000')
+client.api_key = config['api_key'] || "YOUR_API_KEY"
+client.api_username = config['api_username'] || "YOUR_USERNAME"
+
+# generate user api key
+response = client.generate_user_api_key(
+  key: {
+    description: "Key to The Batmobile",
+    username: "batman"
+  }
+)
+
+puts response
+# sample output: {"key"=>{"id"=>13, "key"=>"abc", "truncated_key"=>"abc", "description"=>"Key to The Batmobile"}}

--- a/lib/discourse_api/api/api_key.rb
+++ b/lib/discourse_api/api/api_key.rb
@@ -7,6 +7,13 @@ module DiscourseApi
         response.body
       end
 
+      def generate_user_api_key(args)
+        args = API.params(args)
+          .required(:key)
+          .to_h
+        response = post("/admin/api/keys", args)
+      end
+
       def generate_master_key
         response = post("/admin/api/key")
       end

--- a/spec/discourse_api/api/api_key_spec.rb
+++ b/spec/discourse_api/api/api_key_spec.rb
@@ -31,6 +31,20 @@ describe DiscourseApi::API::ApiKey do
     end
   end
 
+  describe "#generate_user_api_key" do
+    before do
+      url = "#{host}/admin/api/keys"
+      stub_post(url).to_return(body: fixture("generate_user_api_key.json"),
+                               headers: { content_type: "application/json" })
+    end
+
+    it "returns the generated user api key" do
+      api_key = subject.generate_user_api_key(key: { username: 'robin' })
+      expect(api_key).to be_a Hash
+      expect(api_key['key']).to have_key('key')
+    end
+  end
+
   describe "#generate_master_key" do
     before do
       url = "#{host}/admin/api/key"

--- a/spec/fixtures/generate_user_api_key.json
+++ b/spec/fixtures/generate_user_api_key.json
@@ -1,0 +1,12 @@
+{
+  "key": {
+    "id": 5,
+    "key": "e722e04df8cf6d097d565ca04eea1ff8e9e8f09beb405bae6f0c79852916f334",
+    "user": {
+      "id": 2,
+      "username": "robin",
+      "uploaded_avatar_id": 3,
+      "avatar_template": "/user_avatar/localhost/robin/{size}/3.png"
+    }
+  }
+}


### PR DESCRIPTION
I believe old way was removed in #198. This adds new way.