### PR TITLE
Return full response body when fetching categories

### DIFF
--- a/examples/category.rb
+++ b/examples/category.rb
@@ -14,6 +14,9 @@ puts client.categories()
 # get sub categories for parent category with id 2
 puts client.categories(parent_category_id: 2)
 
+# get the full categories response
+puts client.categories_full()
+
 # List topics in a category
 category_topics = client.category_latest_topics(category_slug: "test-category")
 puts category_topics

--- a/lib/discourse_api/api/categories.rb
+++ b/lib/discourse_api/api/categories.rb
@@ -36,11 +36,24 @@ module DiscourseApi
       end
 
       def categories(params = {})
+        categories_full(params)['category_list']['categories']
+      end
+
+      def categories_full(params = {})
         response = get('/categories.json', params)
-        response[:body]['category_list']['categories']
+        response[:body]
       end
 
       def category_latest_topics(args = {})
+        response = category_latest_topics_full(args)
+        if response['errors']
+          response['errors']
+        else
+          response['topic_list']['topics']
+        end
+      end
+
+      def category_latest_topics_full(args = {})
         params = API.params(args)
           .required(:category_slug)
           .optional(:page).to_h
@@ -49,25 +62,31 @@ module DiscourseApi
           url = "#{url}?page=#{params[:page]}"
         end
         response = get(url)
-        if response[:body]['errors']
-          response[:body]['errors']
-        else
-          response[:body]['topic_list']['topics']
-        end
+        response[:body]
       end
 
       def category_top_topics(category_slug)
-        response = get("/c/#{category_slug}/l/top.json")
-        if response[:body]['errors']
-          response[:body]['errors']
+        response = category_top_topics_full(category_slug)
+        if response['errors']
+          response['errors']
         else
-          response[:body]['topic_list']['topics']
+          response['topic_list']['topics']
         end
       end
 
+      def category_top_topics_full(category_slug)
+        response = get("/c/#{category_slug}/l/top.json")
+        response[:body]
+      end
+
       def category_new_topics(category_slug)
+        response = category_new_topics_full(category_slug)
+        response['topic_list']['topics']
+      end
+
+      def category_new_topics_full(category_slug)
         response = get("/c/#{category_slug}/l/new.json")
-        response[:body]['topic_list']['topics']
+        response[:body]
       end
 
       def category(id)

--- a/spec/discourse_api/api/categories_spec.rb
+++ b/spec/discourse_api/api/categories_spec.rb
@@ -28,6 +28,25 @@ describe DiscourseApi::API::Categories do
     end
   end
 
+  describe "#categories_full" do
+    before do
+      stub_get("#{host}/categories.json")
+        .to_return(body: fixture("categories.json"), headers: { content_type: "application/json" })
+    end
+
+    it "requests the correct resource" do
+      subject.categories
+      expect(a_get("#{host}/categories.json")).to have_been_made
+    end
+
+    it "returns the entire categories response" do
+      categories = subject.categories_full
+      expect(categories).to be_a Hash
+      expect(categories).to have_key 'category_list'
+      expect(categories).to have_key 'featured_users'
+    end
+  end
+
   describe '#category_latest_topics' do
     before do
       stub_get("#{host}/c/category-slug/l/latest.json")
@@ -37,6 +56,20 @@ describe DiscourseApi::API::Categories do
     it "returns the latest topics in a category" do
       latest_topics = subject.category_latest_topics(category_slug: 'category-slug')
       expect(latest_topics).to be_an Array
+    end
+  end
+
+  describe '#category_latest_topics_full' do
+    before do
+      stub_get("#{host}/c/category-slug/l/latest.json")
+        .to_return(body: fixture("category_latest_topics.json"), headers: { content_type: "application/json" })
+    end
+
+    it "returns the entire latest topics in a category response" do
+      latest_topics = subject.category_latest_topics_full(category_slug: 'category-slug')
+      expect(latest_topics).to be_a Hash
+      expect(latest_topics).to have_key 'topic_list'
+      expect(latest_topics).to have_key 'users'
     end
   end
 
@@ -55,6 +88,23 @@ describe DiscourseApi::API::Categories do
     end
   end
 
+  describe '#category_top_topics_full' do
+    before do
+      stub_get("#{host}/c/category-slug/l/top.json")
+        .to_return(
+        body: fixture("category_topics.json"),
+        headers: { content_type: "application/json" }
+      )
+    end
+
+    it "returns the entire top topics in a category response" do
+      topics = subject.category_top_topics_full('category-slug')
+      expect(topics).to be_a Hash
+      expect(topics).to have_key 'topic_list'
+      expect(topics).to have_key 'users'
+    end
+  end
+
   describe '#category_new_topics' do
     before do
       stub_get("#{host}/c/category-slug/l/new.json")
@@ -67,6 +117,23 @@ describe DiscourseApi::API::Categories do
     it "returns the new topics in a category" do
       topics = subject.category_new_topics('category-slug')
       expect(topics).to be_an Array
+    end
+  end
+
+  describe '#category_new_topics_full' do
+    before do
+      stub_get("#{host}/c/category-slug/l/new.json")
+        .to_return(
+        body: fixture("category_topics.json"),
+        headers: { content_type: "application/json" }
+      )
+    end
+
+    it "returns the new topics in a category" do
+      topics = subject.category_new_topics_full('category-slug')
+      expect(topics).to be_a Hash
+      expect(topics).to have_key 'topic_list'
+      expect(topics).to have_key 'users'
     end
   end
 


### PR DESCRIPTION
This is not a fully flushed out PR but enough to get a conversation going around the neglected metadata when fetching categories.

Essentially, I'm trying to access metadata on category response, not just the categories/topics within. Specifically, `can_create_topic` and other permissions, eg:

https://github.com/discourse/discourse_api/blob/74c423c5018cdd8832ba92025fa15ce88790eee0/spec/fixtures/category_latest_topics.json#L10

This would be breaking, of course, but I'm not sure how to accomplish it otherwise. Once we align on direction, I can flush out the remainder and specs.