### PR TITLE
Adds timeout to requests

### DIFF
--- a/lib/discourse_api/error.rb
+++ b/lib/discourse_api/error.rb
@@ -33,4 +33,7 @@ module DiscourseApi
 
   class TooManyRequests < DiscourseError
   end
+
+  class Timeout < DiscourseError
+  end
 end

--- a/spec/discourse_api/client_spec.rb
+++ b/spec/discourse_api/client_spec.rb
@@ -28,6 +28,21 @@ describe DiscourseApi::Client do
     end
   end
 
+  describe "#timeout" do
+    context 'custom timeout' do
+      it "is set to Faraday connection" do
+        expect(subject.send(:connection).options.timeout).to eq(30)
+      end
+    end
+
+    context 'default timeout' do
+      it "is set to Faraday connection" do
+        subject.timeout = 25
+        expect(subject.send(:connection).options.timeout).to eq(25)
+      end
+    end
+  end
+
   describe "#api_key" do
     it "is publically accessible" do
       subject.api_key = "test_d7fd0429940"


### PR DESCRIPTION
Adds option to set Faraday timeout

```
client = DiscourseApi::Client.new("http://try.discourse.org").tap do |c|
  c.timeout = 15
end
```