### PR TITLE
Add _full methods to return full category response (#221)

### DIFF
--- a/examples/category.rb
+++ b/examples/category.rb
@@ -14,6 +14,9 @@ puts client.categories()
 # get sub categories for parent category with id 2
 puts client.categories(parent_category_id: 2)
 
+# get the full categories response
+puts client.categories_full()
+
 # List topics in a category
 category_topics = client.category_latest_topics(category_slug: "test-category")
 puts category_topics

--- a/lib/discourse_api/api/categories.rb
+++ b/lib/discourse_api/api/categories.rb
@@ -36,11 +36,24 @@ module DiscourseApi
       end
 
       def categories(params = {})
+        categories_full(params)['category_list']['categories']
+      end
+
+      def categories_full(params = {})
         response = get('/categories.json', params)
-        response[:body]['category_list']['categories']
+        response[:body]
       end
 
       def category_latest_topics(args = {})
+        response = category_latest_topics_full(args)
+        if response['errors']
+          response['errors']
+        else
+          response['topic_list']['topics']
+        end
+      end
+
+      def category_latest_topics_full(args = {})
         params = API.params(args)
           .required(:category_slug)
           .optional(:page).to_h
@@ -49,25 +62,31 @@ module DiscourseApi
           url = "#{url}?page=#{params[:page]}"
         end
         response = get(url)
-        if response[:body]['errors']
-          response[:body]['errors']
-        else
-          response[:body]['topic_list']['topics']
-        end
+        response[:body]
       end
 
       def category_top_topics(category_slug)
-        response = get("/c/#{category_slug}/l/top.json")
-        if response[:body]['errors']
-          response[:body]['errors']
+        response = category_top_topics_full(category_slug)
+        if response['errors']
+          response['errors']
         else
-          response[:body]['topic_list']['topics']
+          response['topic_list']['topics']
         end
       end
 
+      def category_top_topics_full(category_slug)
+        response = get("/c/#{category_slug}/l/top.json")
+        response[:body]
+      end
+
       def category_new_topics(category_slug)
+        response = category_new_topics_full(category_slug)
+        response['topic_list']['topics']
+      end
+
+      def category_new_topics_full(category_slug)
         response = get("/c/#{category_slug}/l/new.json")
-        response[:body]['topic_list']['topics']
+        response[:body]
       end
 
       def category(id)

--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -25,18 +25,18 @@ module DiscourseApi
       end
 
       def latest_topics(params = {})
-        response = get('/latest.json', params)
-        response[:body]['topic_list']['topics']
+        response = get("/latest.json", params)
+        response[:body]["topic_list"]["topics"]
       end
 
       def top_topics(params = {})
         response = get("/top.json", params)
-        response[:body]['topic_list']['topics']
+        response[:body]["topic_list"]["topics"]
       end
 
       def new_topics(params = {})
         response = get("/new.json", params)
-        response[:body]['topic_list']['topics']
+        response[:body]["topic_list"]["topics"]
       end
 
       def rename_topic(topic_id, title)
@@ -49,7 +49,7 @@ module DiscourseApi
 
       # TODO: Deprecated. Remove after 20201231
       def change_topic_status(topic_slug, topic_id, params = {})
-        deprecated(__method__, 'update_topic_status')
+        deprecated(__method__, "update_topic_status")
         update_topic_status(topic_id, params)
       end
 
@@ -74,13 +74,13 @@ module DiscourseApi
         delete("/t/#{id}.json")
       end
 
-      def topic_posts(topic_id, post_ids = [])
+      def topic_posts(topic_id, post_ids = [], params = {})
         url = ["/t/#{topic_id}/posts.json"]
         if post_ids.count > 0
           url.push('?')
           url.push(post_ids.map { |id| "post_ids[]=#{id}" }.join('&'))
         end
-        response = get(url.join)
+        response = get(url.join, params)
         response[:body]
       end
 

--- a/spec/discourse_api/api/categories_spec.rb
+++ b/spec/discourse_api/api/categories_spec.rb
@@ -28,6 +28,25 @@ describe DiscourseApi::API::Categories do
     end
   end
 
+  describe "#categories_full" do
+    before do
+      stub_get("#{host}/categories.json")
+        .to_return(body: fixture("categories.json"), headers: { content_type: "application/json" })
+    end
+
+    it "requests the correct resource" do
+      subject.categories
+      expect(a_get("#{host}/categories.json")).to have_been_made
+    end
+
+    it "returns the entire categories response" do
+      categories = subject.categories_full
+      expect(categories).to be_a Hash
+      expect(categories).to have_key 'category_list'
+      expect(categories).to have_key 'featured_users'
+    end
+  end
+
   describe '#category_latest_topics' do
     before do
       stub_get("#{host}/c/category-slug/l/latest.json")
@@ -37,6 +56,20 @@ describe DiscourseApi::API::Categories do
     it "returns the latest topics in a category" do
       latest_topics = subject.category_latest_topics(category_slug: 'category-slug')
       expect(latest_topics).to be_an Array
+    end
+  end
+
+  describe '#category_latest_topics_full' do
+    before do
+      stub_get("#{host}/c/category-slug/l/latest.json")
+        .to_return(body: fixture("category_latest_topics.json"), headers: { content_type: "application/json" })
+    end
+
+    it "returns the entire latest topics in a category response" do
+      latest_topics = subject.category_latest_topics_full(category_slug: 'category-slug')
+      expect(latest_topics).to be_a Hash
+      expect(latest_topics).to have_key 'topic_list'
+      expect(latest_topics).to have_key 'users'
     end
   end
 
@@ -55,6 +88,23 @@ describe DiscourseApi::API::Categories do
     end
   end
 
+  describe '#category_top_topics_full' do
+    before do
+      stub_get("#{host}/c/category-slug/l/top.json")
+        .to_return(
+        body: fixture("category_topics.json"),
+        headers: { content_type: "application/json" }
+      )
+    end
+
+    it "returns the entire top topics in a category response" do
+      topics = subject.category_top_topics_full('category-slug')
+      expect(topics).to be_a Hash
+      expect(topics).to have_key 'topic_list'
+      expect(topics).to have_key 'users'
+    end
+  end
+
   describe '#category_new_topics' do
     before do
       stub_get("#{host}/c/category-slug/l/new.json")
@@ -67,6 +117,23 @@ describe DiscourseApi::API::Categories do
     it "returns the new topics in a category" do
       topics = subject.category_new_topics('category-slug')
       expect(topics).to be_an Array
+    end
+  end
+
+  describe '#category_new_topics_full' do
+    before do
+      stub_get("#{host}/c/category-slug/l/new.json")
+        .to_return(
+        body: fixture("category_topics.json"),
+        headers: { content_type: "application/json" }
+      )
+    end
+
+    it "returns the new topics in a category" do
+      topics = subject.category_new_topics_full('category-slug')
+      expect(topics).to be_a Hash
+      expect(topics).to have_key 'topic_list'
+      expect(topics).to have_key 'users'
     end
   end
 


### PR DESCRIPTION
supports https://github.com/vangst/oogmerk/issues/670

Adds `params` to topic_posts query to allow for `raw` to be returned. 