### PR TITLE
adds params to get topic_posts

### DIFF
--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -74,13 +74,22 @@ module DiscourseApi
         delete("/t/#{id}.json")
       end
 
-      def topic_posts(topic_id, post_ids = [])
+      def topic_posts(topic_id, post_ids = [], params = {})
+        params = API.params(params)
+          .optional(:asc,
+            :filter,
+            :include_raw,
+            :include_suggested,
+            :post_number,
+            :username_filters,
+          )
+
         url = ["/t/#{topic_id}/posts.json"]
         if post_ids.count > 0
           url.push('?')
           url.push(post_ids.map { |id| "post_ids[]=#{id}" }.join('&'))
         end
-        response = get(url.join)
+        response = get(url.join, params)
         response[:body]
       end
 

--- a/spec/discourse_api/api/topics_spec.rb
+++ b/spec/discourse_api/api/topics_spec.rb
@@ -170,6 +170,14 @@ describe DiscourseApi::API::Topics do
       expect(body['post_stream']['posts']).to be_an Array
       expect(body['post_stream']['posts'].first).to be_a Hash
     end
+
+    it "can retrieve a topic posts' raw attribute" do
+      body = subject.topic_posts(57, [123], { include_raw: true })
+      expect(body).to be_a Hash
+      expect(body['post_stream']['posts']).to be_an Array
+      expect(body['post_stream']['posts'].first).to be_a Hash
+      expect(body['post_stream']['posts'].first['raw']).to be_an Array
+    end
   end
 
   describe "#create_topic_with_tags" do

--- a/spec/fixtures/topic_posts.json
+++ b/spec/fixtures/topic_posts.json
@@ -34,6 +34,7 @@
         "read":true,
         "user_title":null,
         "actions_summary":[{"id":2,"count":3,"can_act":true}],
+        "raw": [{"type":"paragraph","children":[{"text":"This is a raw post  I've got white   space!... and emojis 😈😈😈😈😈😈"}]}],
         "moderator":false,
         "admin":false,
         "staff":false,


### PR DESCRIPTION
This allows you to pass params to the get `topic_posts` or `/t/:topic_id/posts.json` endpoint

Small change, but I think this captures it all. Let me know if I've missed something.