### PR TITLE
DEPRECATED: create_private_message

### DIFF
--- a/lib/discourse_api/api/private_messages.rb
+++ b/lib/discourse_api/api/private_messages.rb
@@ -3,13 +3,20 @@ module DiscourseApi
   module API
     module PrivateMessages
 
-      # :target_usernames REQUIRED comma separated list of usernames
+      # TODO: Deprecated. Remove after 20220628
+      def create_private_message(args = {})
+        deprecated(__method__, 'create_pm')
+        args[:target_recipients] = args.delete :target_usernames
+        create_pm(args.to_h)
+      end
+
+      # :target_recipients REQUIRED comma separated list of usernames
       # :category OPTIONAL name of category, not ID
       # :created_at OPTIONAL seconds since epoch.
-      def create_private_message(args = {})
+      def create_pm(args = {})
         args[:archetype] = 'private_message'
         args = API.params(args)
-          .required(:title, :raw, :target_usernames, :archetype)
+          .required(:title, :raw, :target_recipients, :archetype)
           .optional(:category, :created_at, :api_username)
         post("/posts", args.to_h)
       end

--- a/spec/discourse_api/api/private_messages_spec.rb
+++ b/spec/discourse_api/api/private_messages_spec.rb
@@ -36,19 +36,19 @@ describe DiscourseApi::API::PrivateMessages do
     end
   end
 
-  describe '#create_private_message' do
+  describe '#create_pm' do
     before do
       stub_post("#{host}/posts")
-      subject.create_private_message(
+      subject.create_pm(
         title: "Confidential: Hello World!",
         raw: "This is the raw markdown for my private message",
-        target_usernames: "user1,user2"
+        target_recipients: "user1,user2"
       )
     end
 
     it "makes a create private message request" do
       expect(a_post("#{host}/posts").with(body:
-          'archetype=private_message&raw=This+is+the+raw+markdown+for+my+private+message&target_usernames=user1%2Cuser2&title=Confidential%3A+Hello+World%21')
+          'archetype=private_message&raw=This+is+the+raw+markdown+for+my+private+message&target_recipients=user1%2Cuser2&title=Confidential%3A+Hello+World%21')
         ).to have_been_made
     end
   end


### PR DESCRIPTION
`create_private_message` has been deprecated to remove the use of the
`target_usernames` parameter. A deprecation warning message will now be
outputed if you use that method. Please use `create_pm` from now on with
the `target_recipients` param.