### PR TITLE
Fixes the timeout error

### DIFF
--- a/lib/discourse_api/error.rb
+++ b/lib/discourse_api/error.rb
@@ -34,6 +34,6 @@ module DiscourseApi
   class TooManyRequests < DiscourseError
   end
 
-  class Timeout < DiscourseError
+  class Timeout < Error
   end
 end

--- a/spec/discourse_api/client_spec.rb
+++ b/spec/discourse_api/client_spec.rb
@@ -41,6 +41,12 @@ describe DiscourseApi::Client do
         expect(subject.send(:connection).options.timeout).to eq(25)
       end
     end
+
+    it "raises DiscourseApi::Timeout" do
+      stub_get("#{host}/t/1.json").to_timeout
+
+      expect { subject.topic(1) }.to raise_error(DiscourseApi::Timeout)
+    end
   end
 
   describe "#api_key" do


### PR DESCRIPTION
When the timeout is raised by `faraday`, `discourse_api` tries raise `DiscourseApi::Timeout` but it instead raise `ArgumentError (wrong number of arguments (given 0, expected 1..2))`. It raises this because `DiscourseApi::Timeout` inherits from `DiscourseApi::DiscourseError` which explitcly requies `message` arguement on intialization.

Solution: `DiscourseApi::Timeout` should inherit from `DiscourseApi::Error`, as `DiscourseApi::Error` derives exception message from `$!`.

bug repro script:

```ruby
require 'bundler/inline'

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem 'discourse_api', '~> 0.47.0'
  gem 'minitest'
end

require "minitest/autorun"
require "discourse_api"

client = DiscourseApi::Client.new("https://this-definitely-doesnt-exist.com")

class BugTest < Minitest::Test
  def setup
    @client = DiscourseApi::Client.new("https://#{SecureRandom.uuid}.com")
    @client.timeout= 1
  end

  def test_timeout
    assert_raises DiscourseApi::Timeout do
      @client.topic(1223)
    end
  end
end
```
```bash
# Running:

F

Finished in 0.201250s, 4.9689 runs/s, 4.9689 assertions/s.

  1) Failure:
BugTest#test_timeout [test.rb:23]:
[DiscourseApi::Timeout] exception expected, not
Class: <ArgumentError>
Message: <"wrong number of arguments (given 0, expected 1..2)">
---Backtrace---
/Users/akshay/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/discourse_api-0.47.0/lib/discourse_api/error.rb:6:in `initialize'
/Users/akshay/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/discourse_api-0.47.0/lib/discourse_api/client.rb:172:in `exception'
/Users/akshay/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/discourse_api-0.47.0/lib/discourse_api/client.rb:172:in `raise'
/Users/akshay/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/discourse_api-0.47.0/lib/discourse_api/client.rb:172:in `rescue in request'
/Users/akshay/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/discourse_api-0.47.0/lib/discourse_api/client.rb:161:in `request'
/Users/akshay/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/discourse_api-0.47.0/lib/discourse_api/client.rb:97:in `get'
/Users/akshay/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/discourse_api-0.47.0/lib/discourse_api/api/topics.rb:64:in `topic'
test.rb:24:in `block in test_timeout'
---------------

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```