### PR TITLE
users: add anonymize as an option

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -102,6 +102,10 @@ module DiscourseApi
         put("/admin/users/#{user_id}/unsuspend")
       end
 
+      def anonymize(user_id)
+        put("/admin/users/#{user_id}/anonymize")
+      end
+
       def delete_user(user_id, delete_posts = false)
         delete("/admin/users/#{user_id}.json?delete_posts=#{delete_posts}")
       end

--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -306,6 +306,21 @@ describe DiscourseApi::API::Users do
     end
   end
 
+  describe "#anonymize" do
+    before do
+      url = "#{host}/admin/users/11/anonymize"
+      stub_put(url).to_return(body: '', status: 200)
+    end
+
+    it "makes the correct put request" do
+      result = subject.anonymize(11)
+      url = "#{host}/admin/users/11/anonymize"
+      expect(a_put(url)).to have_been_made
+      expect(result.body).to eq('{"success": true}')
+      expect(result.status).to eq(200)
+    end
+  end
+
   describe "#delete_user" do
     before do
       url = "#{host}/admin/users/11.json?delete_posts=true"

--- a/spec/discourse_api/api/users_spec.rb
+++ b/spec/discourse_api/api/users_spec.rb
@@ -316,7 +316,6 @@ describe DiscourseApi::API::Users do
       result = subject.anonymize(11)
       url = "#{host}/admin/users/11/anonymize"
       expect(a_put(url)).to have_been_made
-      expect(result.body).to eq('{"success": true}')
       expect(result.status).to eq(200)
     end
   end


### PR DESCRIPTION
Adds a new method for anonymizing users ([API docs here](https://docs.discourse.org/#operation/anonymizeUser)).