### PR TITLE
FIX: Make `DiscourseApi::SingleSignOn#groups` return a better array

### DIFF
--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -38,7 +38,7 @@ module DiscourseApi
         if BOOLS.include? k
           val = ["true", "false"].include?(val) ? val == "true" : nil
         end
-        val = Array(val) if ARRAYS.include?(k) && !val.nil?
+        val = val.split(",") if ARRAYS.include?(k) && !val.nil?
         sso.send("#{k}=", val)
       end
 
@@ -79,7 +79,7 @@ module DiscourseApi
         if BOOLS.include? k
           val = ["true", "false"].include?(val) ? val == "true" : nil
         end
-        val = Array(val) if ARRAYS.include?(k) && !val.nil?
+        val = val.split(",") if ARRAYS.include?(k) && !val.nil?
         sso.send("#{k}=", val)
       end
 


### PR DESCRIPTION
`DiscourseApi::SingleSignOn#groups` currently returns an array with a single string that contains all the user's groups comma-concatenated. This API is not very friendly to use, so this PR changes the method to make it return a proper array where each element/string is a group name.