### PR TITLE
DEV: Add new Discourse Connect attributes

### DIFF
--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -5,12 +5,46 @@ require 'openssl'
 
 module DiscourseApi
   class SingleSignOn
-    ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :profile_background_url, :card_background_url, :avatar_force_update, :require_activation,
-                 :bio, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message, :title,
-                 :add_groups, :remove_groups, :groups, :locale, :locale_force_update]
+    ACCESSORS = [
+      :add_groups,
+      :admin,
+      :avatar_force_update,
+      :avatar_url,
+      :bio,
+      :card_background_url,
+      :confirmed_2fa,
+      :email,
+      :external_id,
+      :groups,
+      :locale,
+      :locale_force_update,
+      :moderator,
+      :name,
+      :no_2fa_methods,
+      :nonce,
+      :profile_background_url,
+      :remove_groups,
+      :require_2fa,
+      :require_activation,
+      :return_sso_url,
+      :suppress_welcome_message,
+      :title,
+      :username,
+    ]
+
     FIXNUMS = []
-    BOOLS = [:avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message,
-      :locale_force_update]
+
+    BOOLS = [
+      :admin,
+      :avatar_force_update,
+      :confirmed_2fa,
+      :locale_force_update,
+      :moderator,
+      :no_2fa_methods,
+      :require_2fa,
+      :require_activation,
+      :suppress_welcome_message,
+    ]
     ARRAYS = [:groups]
     #NONCE_EXPIRY_TIME = 10.minutes # minutes is a rails method and is causing an error. Is this needed in the api?
 

--- a/spec/discourse_api/api/sso_spec.rb
+++ b/spec/discourse_api/api/sso_spec.rb
@@ -27,10 +27,10 @@ describe DiscourseApi::API::SSO do
     }
   end
   let(:expected_unsigned_payload) do
-    'name=Some+User&username=some_user&email=some%40email.com&'\
-    'avatar_url=https%3A%2F%2Fwww.website.com&external_id=abc&title=ruby'\
-    '&add_groups=a&add_groups=b&remove_groups=c&remove_groups=d&custom.field_2=potato&'\
-    'custom.custom.field_1=tomato'
+    'add_groups=a&add_groups=b&avatar_url=https%3A%2F%2Fwww.website.com'\
+    '&email=some%40email.com&external_id=abc&name=Some+User&remove_groups=c'\
+    '&remove_groups=d&title=ruby&username=some_user&custom.field_2=potato'\
+    '&custom.custom.field_1=tomato'
   end
   let(:sso_double) { DiscourseApi::SingleSignOn.parse_hash(params) }
 


### PR DESCRIPTION
Discourse Connect has new attributes in core, so we need to add them in this gem. See core commit https://github.com/discourse/discourse/commit/eb5a3cfded114ad1ef701e9e3f495c98d2f70ebd.