### PR TITLE
version bump to 0.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.1] - 2022-04-13
+### Added
+- New attributes for Discourse Connect (aka SSO)
+
 ## [0.48.0] - 2022-01-28
 ### Added
 - `group_add_owners` method (#239)

--- a/lib/discourse_api/version.rb
+++ b/lib/discourse_api/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseApi
-  VERSION = "0.48.0"
+  VERSION = "0.48.1"
 end


### PR DESCRIPTION
To release https://github.com/discourse/discourse_api/pull/245.