### PR TITLE
Version 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
 
 jobs:
@@ -14,13 +13,13 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5
-          - 2.6
-          - 2.7
-          - 3.0
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
@@ -35,15 +34,15 @@ jobs:
         run: bundle exec rake test
 
   publish:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Release Gem
-        uses: discourse/publish-rubygems-action@v2-beta
+        uses: discourse/publish-rubygems-action@v2
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
           GIT_EMAIL: team@discourse.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2022-05-01
+### Changed
+- The package now requires ruby 2.6+
+
 ## [0.48.1] - 2022-04-13
 ### Added
 - New attributes for Discourse Connect (aka SSO)
@@ -65,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.43.1] - 2020-11-04
 ### Fixed
-- Tagged version 0.43.0 got pushed without commmit due to new master branch
+- Tagged version 0.43.0 got pushed without commit due to new master branch
   protections in github. No, code changes here just making sure tags align with
   commits.
 
@@ -118,7 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.38.0] - 2019-10-18
 ### Added
 - Allow setting locale in SingleSignOn
-- Optional param to group memebrs to include owners as well as members
+- Optional param to group members to include owners as well as members
 
 ## [0.37.0] - 2019-09-23
 ### Added
@@ -131,7 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added poll methods
 ### Fixed
 - Updated create topic example
-- Fixed capialization for header auth keys
+- Fixed capitalization for header auth keys
 
 ## [0.35.0] - 2019-05-15
 ### Added
@@ -293,7 +297,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - group_members: Allows you to retrieve more than 100 users with pagination (offset &
   limit)
 ### Fixed
-- Deprication warning with SimpleCov
+- Deprecation warning with SimpleCov
 - updated rack dependency and added ruby 2.3 to travis config
 
 ## [0.9.1] - 2016-03-23

--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '~> 1.0'
   spec.add_runtime_dependency 'faraday_middleware', '~> 1.0'
   spec.add_runtime_dependency 'rack', '>= 1.6'
+  spec.add_runtime_dependency 'uri'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'guard', '~> 2.14'
@@ -30,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'simplecov', '~> 0.11'
   spec.add_development_dependency 'webmock', '~> 3.0'
-  spec.add_development_dependency 'rubocop-discourse', '~> 2.4.1'
+  spec.add_development_dependency 'rubocop-discourse', '~> 2.5.0'
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 end

--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '~> 1.0'
   spec.add_runtime_dependency 'faraday_middleware', '~> 1.0'
   spec.add_runtime_dependency 'rack', '>= 1.6'
-  spec.add_runtime_dependency 'uri'
+  spec.add_runtime_dependency 'uri', '>= 0.10'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'guard', '~> 2.14'

--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '~> 1.0'
   spec.add_runtime_dependency 'faraday_middleware', '~> 1.0'
   spec.add_runtime_dependency 'rack', '>= 1.6'
-  spec.add_runtime_dependency 'uri', '>= 0.10'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'guard', '~> 2.14'

--- a/lib/discourse_api/version.rb
+++ b/lib/discourse_api/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseApi
-  VERSION = "0.48.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Update minimum ruby to 2.6, update the CI workflow, fix warnings by adding `uri` gem.