### PR TITLE
FEATURE: Change error raised by the SSO parse method to a custom error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-07-01
+### Changed
+- `DiscourseApi::SingleSignOn.parse` now raises `DiscourseApi::SingleSignOn::ParseError` instead of `RuntimeError` when there's a signature mismatch or `sso_secret` or `sso_url` are missing. `DiscourseApi::SingleSignOn::ParseError` inherits from `RuntimeError` so existing `rescue` blocks will continue to work.
+
 ## [1.0.0] - 2022-05-01
 ### Changed
 - The package now requires ruby 2.6+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0] - 2022-07-01
+## [1.1.0] - 2022-07-05
 ### Changed
-- `DiscourseApi::SingleSignOn.parse` now raises `DiscourseApi::SingleSignOn::ParseError` instead of `RuntimeError` when there's a signature mismatch or `sso_secret` or `sso_url` are missing. `DiscourseApi::SingleSignOn::ParseError` inherits from `RuntimeError` so existing `rescue` blocks will continue to work.
+- `DiscourseApi::SingleSignOn.parse` now raises `DiscourseApi::SingleSignOn::ParseError` (inherits from `RuntimeError` to preserve backward compatibility) instead of `RuntimeError` when there's a signature mismatch.
+- `DiscourseApi::SingleSignOn.parse` now raises `DiscourseApi::SingleSignOn::MissingConfigError` (also inherits from `RuntimeError`) if `sso_secret` or `sso_url` are missing.
 
 ## [1.0.0] - 2022-05-01
 ### Changed

--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -11,6 +11,7 @@ module DiscourseApi
     # changed it to a custom error (ParseError) to make it possible to rescue
     # exceptions that only relate to parsing errors
     class ParseError < RuntimeError; end
+    class MissingConfigError < RuntimeError; end
 
     ACCESSORS = [
       :add_groups,
@@ -59,11 +60,11 @@ module DiscourseApi
     attr_writer :custom_fields, :sso_secret, :sso_url
 
     def self.sso_secret
-      raise ParseError, "sso_secret not implemented on class, be sure to set it on instance"
+      raise MissingConfigError, "sso_secret not implemented on class, be sure to set it on instance"
     end
 
     def self.sso_url
-      raise ParseError, "sso_url not implemented on class, be sure to set it on instance"
+      raise MissingConfigError, "sso_url not implemented on class, be sure to set it on instance"
     end
 
     def self.parse_hash(payload)

--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -5,11 +5,6 @@ require 'openssl'
 
 module DiscourseApi
   class SingleSignOn
-    # We inherit from RuntimeError instead of StandardError for backward
-    # compatibility reasons. We used to raise RuntimeError but that was too
-    # generic and could be raised by libraries/code from other sources so we
-    # changed it to a custom error (ParseError) to make it possible to rescue
-    # exceptions that only relate to parsing errors
     class ParseError < RuntimeError; end
     class MissingConfigError < RuntimeError; end
 

--- a/lib/discourse_api/version.rb
+++ b/lib/discourse_api/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseApi
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/discourse_api/single_sign_on_spec.rb
+++ b/spec/discourse_api/single_sign_on_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe DiscourseApi::SingleSignOn do
+  context "::MissingConfigError" do
+    it "inherits from RuntimeError for backward compatibility" do
+      expect(DiscourseApi::SingleSignOn::MissingConfigError).to be < RuntimeError
+    end
+  end
+
+  context "::ParseError" do
+    it "inherits from RuntimeError for backward compatibility" do
+      expect(DiscourseApi::SingleSignOn::ParseError).to be < RuntimeError
+    end
+  end
+
+  context ".sso_secret" do
+    it "raises MissingConfigError when sso_secret is not present" do
+      expect {
+        described_class.sso_secret
+      }.to raise_error(DiscourseApi::SingleSignOn::MissingConfigError)
+    end
+  end
+
+  context ".sso_url" do
+    it "raises MissingConfigError when sso_url is not present" do
+      expect {
+        described_class.sso_url
+      }.to raise_error(DiscourseApi::SingleSignOn::MissingConfigError)
+    end
+  end
+
+  context ".parse" do
+    it "raises ParseError when there's a signature mismatch" do
+      sso = described_class.new
+      sso.sso_secret = "abcd"
+      expect {
+        described_class.parse(sso.payload, "dcba")
+      }.to raise_error(DiscourseApi::SingleSignOn::ParseError)
+    end
+  end
+end


### PR DESCRIPTION
@tgxworld I went with bumping the minor version, but should we do a major version bump? Some consumers may be too specific and expect the `parse` method to raise `RuntimeError`, so I'm not completely sure.