### PR TITLE
Upgrade to Faraday v2

### DIFF
--- a/discourse_api.gemspec
+++ b/discourse_api.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday', '~> 1.0'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 1.0'
+  spec.add_runtime_dependency 'faraday', '~> 2.7.4'
+  spec.add_runtime_dependency 'faraday-follow_redirects'
+  spec.add_runtime_dependency 'faraday-multipart'
   spec.add_runtime_dependency 'rack', '>= 1.6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/discourse_api/client.rb
+++ b/lib/discourse_api/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/follow_redirects'
+require 'faraday/multipart'
 require 'json'
 require 'uri'
 require 'discourse_api/version'
@@ -135,7 +136,7 @@ module DiscourseApi
 
         # Allow to interact with forums behind basic HTTP authentication
         if basic_auth
-          conn.request :basic_auth, basic_auth[:user], basic_auth[:password]
+          conn.request :authorization, :basic, basic_auth[:user], basic_auth[:password]
         end
 
         # Follow redirects


### PR DESCRIPTION
Upgrades Faraday to v2.7.4 and adds middleware dependencies found on: https://github.com/lostisland/awesome-faraday

1. The main discourse repo currently uses [v2.7.4](https://github.com/discourse/discourse/blob/main/Gemfile.lock#L149)
2. Other gems we use currently have a dependency on >= 2.0