### PR TITLE
DEV: `invite_admin` endpoint is no longer available in Discourse core.

### DIFF
--- a/lib/discourse_api/api/users.rb
+++ b/lib/discourse_api/api/users.rb
@@ -73,10 +73,6 @@ module DiscourseApi
         post("/admin/users/#{id}/log_out")
       end
 
-      def invite_admin(args = {})
-        post("/admin/users/invite_admin", args)
-      end
-
       def list_users(type, params = {})
         response = get("admin/users/list/#{type}.json", params)
         response[:body]

--- a/lib/discourse_api/version.rb
+++ b/lib/discourse_api/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseApi
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/a157f4aaaa8315e83d5be79e12aa630f11524c20