### PR TITLE
FIX: Revert formatting of sync_sso groups to match API

### DIFF
--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -75,7 +75,7 @@ module DiscourseApi
 
         val = val.to_i if FIXNUMS.include? k
         val = %w[true false].include?(val) ? val == "true" : nil if BOOLS.include? k
-        val = val.split(",") if ARRAYS.include?(k) && !val.nil?
+        val = Array(val) if ARRAYS.include?(k) && !val.nil?
         sso.send("#{k}=", val)
       end
 

--- a/spec/discourse_api/api/sso_spec.rb
+++ b/spec/discourse_api/api/sso_spec.rb
@@ -18,7 +18,7 @@ describe DiscourseApi::API::SSO do
       :avatar_force_update => false,
       :add_groups => %w[a b],
       :remove_groups => %w[c d],
-      :groups => 'a,b',
+      :groups => "a,b",
       # old format (which results in custom.custom.field_1 in unsigned_payload)
       "custom.field_1" => "tomato",
       # new format
@@ -46,7 +46,6 @@ describe DiscourseApi::API::SSO do
     end
 
     it "assigns params to sso instance" do
-      RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
       allow(DiscourseApi::SingleSignOn).to(receive(:parse_hash).with(params).and_return(sso_double))
 
       subject.sync_sso(params)

--- a/spec/discourse_api/api/sso_spec.rb
+++ b/spec/discourse_api/api/sso_spec.rb
@@ -18,6 +18,7 @@ describe DiscourseApi::API::SSO do
       :avatar_force_update => false,
       :add_groups => %w[a b],
       :remove_groups => %w[c d],
+      :groups => 'a,b',
       # old format (which results in custom.custom.field_1 in unsigned_payload)
       "custom.field_1" => "tomato",
       # new format
@@ -28,7 +29,7 @@ describe DiscourseApi::API::SSO do
   end
   let(:expected_unsigned_payload) do
     "add_groups=a&add_groups=b&avatar_url=https%3A%2F%2Fwww.website.com" \
-      "&email=some%40email.com&external_id=abc&name=Some+User&remove_groups=c" \
+      "&email=some%40email.com&external_id=abc&groups=a%2Cb&name=Some+User&remove_groups=c" \
       "&remove_groups=d&title=ruby&username=some_user&custom.field_2=potato" \
       "&custom.custom.field_1=tomato"
   end
@@ -45,6 +46,7 @@ describe DiscourseApi::API::SSO do
     end
 
     it "assigns params to sso instance" do
+      RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
       allow(DiscourseApi::SingleSignOn).to(receive(:parse_hash).with(params).and_return(sso_double))
 
       subject.sync_sso(params)


### PR DESCRIPTION
After upgrading from 0.47.0. to 0.48.1, I noticed our sync_sso calls started failing with 500s from Discourse. Reviewing the Discourse logs showed that it expects `groups` to be a comma separated string, not an array. [This line here](https://github.com/discourse/discourse/blame/main/app/models/discourse_connect.rb#L186).

This is also mentioned in the [setup doc](https://meta.discourse.org/t/setup-discourseconnect-official-single-sign-on-for-discourse-sso/13045):
> If the [discourse connect](https://meta.discourse.org/t/13045) overrides groups option is specified, Discourse will consider the comma separated list of groups passed in groups.

I am running an older version of discourse (2.8.13) but I do not believe that this API endpoint has changed in new versions.

The [PR that introduced this change](https://github.com/discourse/discourse_api/pull/243) was trying to modify `DiscourseApi::SingleSignOn#groups`, but changed both the `#parse` and `#parse_hash` methods. I believe `#parse_hash` is used exclusively for calling the sync_sso from discourse. Looks like an accidental change.

I am also modifying the spec to check the `groups` option as well. So this behavior is not accidentally changed again.

---

If I'm wrong and there was an API change, feel free to ignore this PR.

Thanks