### PR TITLE
Update single_sign_on.rb to avoid 500 errors on malformed sso queries

### DIFF
--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -100,8 +100,8 @@ module DiscourseApi
       parsed = Rack::Utils.parse_query(payload)
       if parsed["sso"].nil? || sso.sign(parsed["sso"]) != parsed["sig"]
         diags =
-          "\n\nsso: #{parsed["sso"]}\n\nsig: #{parsed["sig"]}\n\nexpected sig: #{sso.sign(parsed["sso"])}"
-        if parsed["sso"] && parsed["sso"] =~ %r{[^a-zA-Z0-9=\r\n/+]}m
+          "\n\nsso: #{parsed["sso"].inspect}\n\nsig: #{parsed["sig"].inspect}\n\nexpected sig: #{sso.sign(parsed.fetch("sso", ''))}"
+        if parsed["sso"].nil? || parsed["sso"] =~ %r{[^a-zA-Z0-9=\r\n/+]}m
           raise ParseError,
                 "The SSO field should be Base64 encoded, using only A-Z, a-z, 0-9, +, /, and = characters. Your input contains characters we don't understand as Base64, see http://en.wikipedia.org/wiki/Base64 #{diags}"
         else

--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -100,7 +100,7 @@ module DiscourseApi
       parsed = Rack::Utils.parse_query(payload)
       if parsed["sso"].nil? || sso.sign(parsed["sso"]) != parsed["sig"]
         diags =
-          "\n\nsso: #{parsed["sso"].inspect}\n\nsig: #{parsed["sig"].inspect}\n\nexpected sig: #{sso.sign(parsed.fetch("sso", ''))}"
+          "\n\nsso: #{parsed["sso"].inspect}\n\nsig: #{parsed["sig"].inspect}\n\nexpected sig: #{sso.sign(parsed.fetch("sso", ""))}"
         if parsed["sso"].nil? || parsed["sso"] =~ %r{[^a-zA-Z0-9=\r\n/+]}m
           raise ParseError,
                 "The SSO field should be Base64 encoded, using only A-Z, a-z, 0-9, +, /, and = characters. Your input contains characters we don't understand as Base64, see http://en.wikipedia.org/wiki/Base64 #{diags}"

--- a/lib/discourse_api/single_sign_on.rb
+++ b/lib/discourse_api/single_sign_on.rb
@@ -98,10 +98,10 @@ module DiscourseApi
       sso.sso_secret = sso_secret if sso_secret
 
       parsed = Rack::Utils.parse_query(payload)
-      if sso.sign(parsed["sso"]) != parsed["sig"]
+      if parsed["sso"].nil? || sso.sign(parsed["sso"]) != parsed["sig"]
         diags =
           "\n\nsso: #{parsed["sso"]}\n\nsig: #{parsed["sig"]}\n\nexpected sig: #{sso.sign(parsed["sso"])}"
-        if parsed["sso"] =~ %r{[^a-zA-Z0-9=\r\n/+]}m
+        if parsed["sso"] && parsed["sso"] =~ %r{[^a-zA-Z0-9=\r\n/+]}m
           raise ParseError,
                 "The SSO field should be Base64 encoded, using only A-Z, a-z, 0-9, +, /, and = characters. Your input contains characters we don't understand as Base64, see http://en.wikipedia.org/wiki/Base64 #{diags}"
         else

--- a/spec/discourse_api/single_sign_on_spec.rb
+++ b/spec/discourse_api/single_sign_on_spec.rb
@@ -46,11 +46,13 @@ describe DiscourseApi::SingleSignOn do
       it "raises ParseError when there's a signature mismatch" do
         sso = described_class.new
         sso.sso_secret = "abcd"
-        missing_sso = Rack::Utils.parse_query(sso.payload).except("sso")
+        missing_sso = Rack::Utils.parse_query(sso.payload)
+        missing_sso.delete("sso")
         malformed_query = Rack::Utils.build_query(missing_sso)
 
         expect { described_class.parse(malformed_query, "dcba") }.to raise_error(
-          DiscourseApi::SingleSignOn::ParseError, /The SSO field should/i
+          DiscourseApi::SingleSignOn::ParseError,
+          /The SSO field should/i,
         )
       end
     end


### PR DESCRIPTION
That string typically comes from the end user so it may not contain sso parameter at all