### PR TITLE
host requires protocol to be included

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -1,6 +1,6 @@
 # Specify your environment by making a copy of this file to create a file in your root directory called config.yml with your environment settings.
 
-# host e.g. localhost:3000 or discourse.my_domain.com
+# host e.g. http://localhost:3000 or https://discourse.my_domain.com
 host: YOUR_HOST_NAME
 
 # api user (can effect results returned, e.g. .categories method returns only the categories your api_username can see)


### PR DESCRIPTION
If the http or https protocol is not prefixed, the following error will be thrown:

```sh
ruby examples/example.rb
```

```
~/discourse_api/config.yml
~/discourse_api/lib/discourse_api/client.rb:193:in `check_subdirectory': undefined method `request_uri' for an instance of URI::Generic (NoMethodError)

      URI(host).request_uri != "/"
               ^^^^^^^^^^^^
        from ~/discourse_api/lib/discourse_api/client.rb:63:in `initialize'
        from examples/example.rb:7:in `new'
```