### PR TITLE
Add 'visible' param when creating a topic

### DIFF
--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -19,6 +19,7 @@ module DiscourseApi
               :api_username,
               :tags,
               :external_id,
+              :visible,
             )
         post("/posts", args.to_h)
       end


### PR DESCRIPTION
Hi!
[Based on the existing code](https://github.com/discourse/discourse/blob/main/app/controllers/posts_controller.rb#L854), I’ve added this parameter so we can create a topic and control its visibility.

Unfortunately, the parameter [isn’t officially documented in the API](https://docs.discourse.org/#tag/Topics/operation/createTopicPostPM), but it does work correctly.
However, the response doesn’t include any visibility information, so I’m not able to add a test for it.

Let me know if this change is okay for you or if you’d prefer something different.
Thanks!